### PR TITLE
feat(sensor): add station coordinates and Location attribute

### DIFF
--- a/custom_components/qld_fuel/coordinator.py
+++ b/custom_components/qld_fuel/coordinator.py
@@ -117,6 +117,8 @@ class QldFuelDataUpdateCoordinator(DataUpdateCoordinator):
                     "name": s_info.get("N"),
                     "address": s_info.get("A"),
                     "postcode": s_info.get("P"),
+                    "latitude": s_info.get("Lat"),
+                    "longitude": s_info.get("Lng"),
                 }
 
             price_map.setdefault(s_id, []).append(clean_price_entry)
@@ -161,12 +163,16 @@ class QldFuelDataUpdateCoordinator(DataUpdateCoordinator):
                         "name": site.get("N"),
                         "address": site.get("A"),
                         "postcode": site.get("P"),
+                        "latitude": site.get("Lat"),
+                        "longitude": site.get("Lng"),
                     }
 
             filtered_sites[s_id] = {
                 "name": site.get("N"),
                 "address": site.get("A"),
                 "postcode": site.get("P"),
+                "latitude": s_lat,
+                "longitude": s_lon,
                 "distance": round(dist, 1),
                 "prices": site_prices,
                 "stats": stats,

--- a/custom_components/qld_fuel/sensor.py
+++ b/custom_components/qld_fuel/sensor.py
@@ -169,6 +169,9 @@ class QldFuelBestPriceSensor(CoordinatorEntity, SensorEntity):
         return {
             "station_name": site_raw.get("N", "Unknown"),
             "address": f"{site_raw.get('A', '')} {site_raw.get('P', '')}".strip(),
+            "latitude": s_lat,
+            "longitude": s_lon,
+            "Location": f"{s_lat}, {s_lon}",
             "distance_km": dist_km,
         }
 
@@ -224,10 +227,14 @@ class FuelPriceSensor(CoordinatorEntity, SensorEntity):
 
         attrs = {
             "address": f"{site.get('address')} {site.get('postcode')}".strip(),
+            "latitude": site.get("latitude"),
+            "longitude": site.get("longitude"),
             "distance": f"{site.get('distance')} km",
             "fuel_id": self.fuel_id,
             "difference_to_qld_cheapest": stats.get("qld_delta", 0),
         }
+        if site.get("latitude") is not None and site.get("longitude") is not None:
+            attrs["Location"] = f"{site.get('latitude')}, {site.get('longitude')}"
 
         if self._7d_low is not None:
             attrs.update({


### PR DESCRIPTION
Sorry for the confusion on the previous pull request.

This updated PR now includes only the intended change: exposing station latitude/longitude and a Home Assistant-style `Location` attribute for sensors.

My inexperience with Git caused the earlier PR to include extra history unintentionally.