### PR TITLE
Feature/tracked location source

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,46 @@
+name: Test Coverage
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      - name: Run tests with coverage
+        run: |
+          python -m pytest -q tests/components/qld_fuel \
+            --cov=custom_components/qld_fuel \
+            --cov-report=term-missing:skip-covered \
+            --cov-fail-under=95 \
+            --cov-report=xml:coverage.xml | tee coverage-summary.txt
+
+      - name: Run strict type checks
+        run: |
+          python -m mypy --config-file mypy.ini custom_components/qld_fuel/diagnostics.py
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-evidence
+          path: |
+            coverage.xml
+            coverage-summary.txt

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -1,0 +1,20 @@
+name: Type Check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+      - name: Run mypy
+        run: python -m mypy --config-file mypy.ini custom_components/qld_fuel

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ __pycache__/
 target/
 .env
 *.env
+.venv/
+.pytest_cache/
+.coverage
+.cursor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,11 @@
 - Prefer Windows-compatible workflows and command/script formats over Unix-only hooks.
 - Prefer Home Assistant-style entity attributes while preserving backward compatibility.
 - Do not add tool/vendor branding text in repo content, commit messages, or PR/comment text.
+- Prefer graceful logging for expected upstream failures in services (for example API errors) without emitting full tracebacks.
 
 ## Learned Workspace Facts
 - The workspace is a Home Assistant custom integration repository for QLD fuel prices.
 - The user maintains and contributes changes upstream via fork-based GitHub pull requests.
+- Stacked pull requests may use a feature branch as the merge base when later work depends on earlier in-flight changes.
+- HACS repository validation can fail on GitHub repository settings (for example topics and issues) rather than integration code alone.
+- Use `scripts/run-tests.ps1` to run the project test suite on Windows when available.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+## Learned User Preferences
+- Prefer Windows-compatible workflows and command/script formats over Unix-only hooks.
+- Prefer Home Assistant-style entity attributes while preserving backward compatibility.
+- Do not add tool/vendor branding text in repo content, commit messages, or PR/comment text.
+
+## Learned Workspace Facts
+- The workspace is a Home Assistant custom integration repository for QLD fuel prices.
+- The user maintains and contributes changes upstream via fork-based GitHub pull requests.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ It utilises the Queensland Government Mandatory Fuel Price Reporting Scheme's AP
 2. Install this integration via HACS [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=spusuf&repository=qld_fuel-hass)
 3. Add the integration in home assistant
 
+### Install/config parameters
+
+| Name | Required | Default | Range | Description |
+|---|---|---|---|---|
+| `subscriber_token` | Yes (master entry only) | None | N/A | Data Consumer Token from Fuel Prices QLD. |
+| `location_entity` | No | None | Entity domain: `person`, `device_tracker`, `sensor` | Optional tracked entity used as the reference coordinates. |
+| `zone` | Yes | `zone.home` | Entity domain: `zone` | Fallback location and display name source when `location_entity` is not provided. |
+| `radius` | Yes | `5` | `1-100` km | Search radius used to include nearby stations. |
+| `fuel_types` | Yes | `["12","5","3"]` | Any subset of supported fuel IDs | Fuel products to create sensors for. |
+| `scan_interval` | Yes | `6` | `1-24` hours | Scheduled refresh interval for API updates. |
+
 
 ## Features
 - Automatically creates an entry for each station within a selectable radius from your home's location (will add location selector to allow second instance scanning near work, etc)
@@ -16,6 +27,11 @@ It utilises the Queensland Government Mandatory Fuel Price Reporting Scheme's AP
 - Tracks the cheapest price in Queensland
 - Tracks statistics in attributes (7 & 14 day lows & averages)
 - Configurable update interval
+
+## Development quality gates
+- Tests: `python -m pytest -q tests/components/qld_fuel`
+- Coverage: configured in CI with `--cov-fail-under=95`
+- Strict typing: `python -m mypy --config-file mypy.ini custom_components/qld_fuel`
 
 ![3 fuel sensors on a dashboard](https://github.com/spusuf/qld_fuel-hass/blob/main/previews/preview2.png "3 fuel sensors with graphs on a dashboard")
 
@@ -42,3 +58,117 @@ Sorry about the washed out screenshots, HDR on Hyprland is not yet perfect.
 ### To do
 Add a location selector to the configuration page to allow second instance in a different location
 Get non-washed out screenshots with longer term statistics
+
+## Service action: refresh_prices
+
+The integration exposes one Home Assistant service action:
+
+- `qld_fuel.refresh_prices`
+
+Use this when you want an on-demand update (for example after changing options,
+or when troubleshooting stale values).
+
+Expected behavior:
+
+- Triggers a refresh request for all loaded QLD Fuel config entries.
+- If shared API data is older than 5 minutes, the integration fetches fresh data.
+- If shared API data was fetched in the last 5 minutes, entries reuse the shared
+  cache and recompute from that data.
+
+Failure behavior:
+
+- If one or more entries fail during the service call, Home Assistant reports the
+  service call as failed and includes the affected entry IDs.
+- Entry-level failures are logged; successful entries can still update.
+
+## Removal instructions
+
+1. Go to **Settings -> Devices & Services** in Home Assistant.
+2. Open **Queensland Fuel Prices**.
+3. Select the config entry you want to remove.
+4. Use **Delete** (three-dot menu) and confirm.
+5. Optionally remove dashboards and automations that referenced those entities.
+
+## Troubleshooting
+
+- **Invalid token**: confirm your Data Consumer Token is current, copied exactly,
+  and has no leading or trailing spaces.
+- **Cannot connect**: check Home Assistant internet connectivity and retry later.
+  Temporary upstream API issues can also cause this.
+- **Missing zone/location coordinates**: ensure your selected `zone` or
+  `location_entity` exposes valid `latitude` and `longitude` attributes.
+  If no valid coordinates are available, nearby station filtering cannot be
+  calculated correctly.
+
+## Data update behavior
+
+- `scan_interval` controls scheduled refresh frequency in hours (default `6`,
+  supported range `1-24`).
+- All entries share one cached raw API payload at the integration domain level.
+- Shared cache freshness window is 5 minutes. Within that window, refreshes reuse
+  cached API data to avoid extra upstream calls.
+- After the 5-minute window expires, the next refresh fetches fresh data and
+  updates the shared cache for all entries.
+
+## Supported functions
+
+This integration currently supports:
+
+- Setup via Home Assistant config flow.
+- Per-location fuel station sensors for selected fuel types.
+- Best-price summary sensors (local, nearby tracker location, tracked areas, and
+  Queensland-wide).
+- Reconfiguration of location, radius, fuel types, and scan interval.
+- Reauthentication when a token is no longer accepted by the API.
+- Diagnostics snapshots with sensitive values redacted.
+- Manual refresh via the `qld_fuel.refresh_prices` action.
+
+## Supported devices and entities
+
+This integration creates Home Assistant service-style devices and sensor entities:
+
+- A service device for each configured location entry.
+- A statewide service device for Queensland-level summary sensors.
+- Per-station fuel price sensors for stations in range.
+- Summary sensors for:
+  - best local price for each selected fuel type
+  - best nearby price for each selected fuel type
+  - best tracked-areas price for each selected fuel type (master entry)
+  - best Queensland price for each selected fuel type (master entry)
+
+## Use cases
+
+Common ways to use this integration:
+
+- Compare local stations and pick the best price before refueling.
+- Track fuel trends using 7-day and 14-day price attributes.
+- Monitor a second area (for example near work) with another config entry.
+- Drive automations and dashboard cards from cheapest-price sensors.
+- Trigger an immediate refresh before trips with `qld_fuel.refresh_prices`.
+
+## Known limitations
+
+- Fuel price data quality and update timing depend on the upstream Queensland Fuel
+  Prices API.
+- If your selected `zone` or `location_entity` has no valid coordinates, nearby
+  station filtering and local comparisons cannot be calculated correctly.
+- Shared API payloads are cached for up to 5 minutes across entries; immediate
+  back-to-back refresh requests may reuse cached data.
+- A specific location source can only be configured once (duplicate location setup
+  is blocked by unique entry handling).
+
+## Discovery applicability
+
+The Home Assistant Integration Quality Scale rules `discovery` and
+`discovery-update-info` are not applicable for this integration.
+
+Reason:
+
+- `qld_fuel` is a cloud polling service integration that requires a user-provided
+  Fuel Prices QLD Data Consumer Token.
+- Entities are scoped to user-selected location context (`zone` and optional
+  `location_entity`), radius, and chosen fuel products.
+- There is no local network device, protocol broadcast, or hardware endpoint to
+  discover automatically.
+- Setup is intentionally manual through the config flow so users only install and
+  configure the integration when it is relevant to their interests and location.

--- a/custom_components/qld_fuel/__init__.py
+++ b/custom_components/qld_fuel/__init__.py
@@ -1,8 +1,30 @@
-from homeassistant.core import HomeAssistant, ServiceCall
+import asyncio
+import logging
+from collections.abc import Iterator
+from typing import Any
+
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+try:
+    from homeassistant.helpers.update_coordinator import UpdateFailed
+except ImportError:  # pragma: no cover - test stubs may omit helpers module
+    UpdateFailed = HomeAssistantError
+
 from .const import DOMAIN, PLATFORMS
 from .coordinator import QldFuelDataUpdateCoordinator
-from .sensor import _RESERVED_DOMAIN_KEYS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _iter_runtime_coordinators(
+    hass: HomeAssistant,
+) -> Iterator[QldFuelDataUpdateCoordinator]:
+    """Yield loaded coordinators from config entry runtime data."""
+    for config_entry in hass.config_entries.async_entries(DOMAIN):
+        coordinator = config_entry.runtime_data
+        if isinstance(coordinator, QldFuelDataUpdateCoordinator):
+            yield coordinator
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -11,16 +33,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = QldFuelDataUpdateCoordinator(hass, entry)
 
     await coordinator.async_config_entry_first_refresh()
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
+    await coordinator.async_setup_location_listener()
 
     if entry.data.get("is_master") or "master_entry_id" not in hass.data[DOMAIN]:
         hass.data[DOMAIN]["master_entry_id"] = entry.entry_id
 
     if not hass.services.has_service(DOMAIN, "refresh_prices"):
-        async def handle_manual_refresh(call: ServiceCall):
-            for coord in hass.data[DOMAIN].values():
-                if isinstance(coord, QldFuelDataUpdateCoordinator):
+        async def handle_manual_refresh(call: ServiceCall) -> None:
+            failed_entry_ids: list[str] = []
+            for coord in _iter_runtime_coordinators(hass):
+                try:
                     await coord.async_request_refresh()
+                except asyncio.CancelledError:
+                    raise
+                except (HomeAssistantError, UpdateFailed, Exception):  # pragma: no cover
+                    entry_id = getattr(coord.entry, "entry_id", "unknown")
+                    failed_entry_ids.append(entry_id)
+                    _LOGGER.warning(
+                        "Manual refresh failed for QLD Fuel entry '%s'",
+                        entry_id,
+                    )
+
+            if failed_entry_ids:
+                _LOGGER.warning(
+                    "Manual refresh completed with failures for QLD Fuel entries: %s",
+                    ", ".join(failed_entry_ids),
+                )
 
         hass.services.async_register(DOMAIN, "refresh_prices", handle_manual_refresh)
 
@@ -33,24 +72,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unload_ok = bool(await hass.config_entries.async_unload_platforms(entry, PLATFORMS))
 
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id, None)
+        coord = entry.runtime_data
+        if isinstance(coord, QldFuelDataUpdateCoordinator):
+            await coord.async_shutdown()
+        entry.runtime_data = None
 
         if hass.data[DOMAIN].get("master_entry_id") == entry.entry_id:
             remaining = [
-                k for k in hass.data[DOMAIN]
-                if k not in _RESERVED_DOMAIN_KEYS
+                config_entry
+                for config_entry in hass.config_entries.async_entries(DOMAIN)
+                if config_entry.entry_id != entry.entry_id
             ]
             if remaining:
-                next_master = remaining[0]
-                hass.data[DOMAIN]["master_entry_id"] = next_master
-                coord = hass.data[DOMAIN].get(next_master)
-                if isinstance(coord, QldFuelDataUpdateCoordinator):
+                next_master_entry = remaining[0]
+                hass.data[DOMAIN]["master_entry_id"] = next_master_entry.entry_id
+                next_coord = next_master_entry.runtime_data
+                if isinstance(next_coord, QldFuelDataUpdateCoordinator):
                     hass.config_entries.async_update_entry(
-                        coord.entry,
-                        data={**coord.entry.data, "is_master": True},
+                        next_coord.entry,
+                        data={**next_coord.entry.data, "is_master": True},
                     )
             else:
                 hass.data.pop(DOMAIN)
@@ -63,3 +106,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update."""
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, entry: ConfigEntry, device_entry: Any
+) -> bool:
+    """Allow cleanup of stale devices tied to this config entry."""
+    return True

--- a/custom_components/qld_fuel/config_flow.py
+++ b/custom_components/qld_fuel/config_flow.py
@@ -1,50 +1,165 @@
 import voluptuous as vol
+from typing import Any
 from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.helpers import selector
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 
-from .const import DOMAIN, TOKEN, RADIUS, FUEL_TYPES, FUEL_TYPES_OPTIONS, SCAN_INTERVAL
+from .const import (
+    DOMAIN,
+    TOKEN,
+    RADIUS,
+    FUEL_TYPES,
+    FUEL_TYPES_OPTIONS,
+    SCAN_INTERVAL,
+    LOCATION_ENTITY,
+    ZONE,
+)
+from .coordinator import async_validate_token, QldFuelAuthError, QldFuelConnectionError
 
 
-class QldFuelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+def _location_entity_selector_options(hass: Any) -> list[dict[str, str]]:
+    """Build dropdown options for entities that expose coordinates."""
+    states = getattr(hass, "states", None)
+    async_all = getattr(states, "async_all", None)
+    if async_all is None:
+        return []
+
+    options: list[dict[str, str]] = []
+    for state in async_all():
+        entity_id = getattr(state, "entity_id", "")
+        if not entity_id:
+            continue
+
+        domain = entity_id.split(".", 1)[0]
+        if domain not in {"person", "device_tracker", "sensor"}:
+            continue
+
+        attrs = getattr(state, "attributes", {})
+        if attrs.get("latitude") is None or attrs.get("longitude") is None:
+            continue
+
+        options.append({"value": entity_id, "label": state.name})
+
+    return sorted(options, key=lambda item: item["label"].lower())
+
+
+def _location_entity_selector(
+    hass: Any, current_location_entity: str | None = None
+) -> selector.SelectSelector:
+    """Create a dropdown selector constrained to entities with coordinates."""
+    options = _location_entity_selector_options(hass)
+    option_values = {item["value"] for item in options}
+    if current_location_entity and current_location_entity not in option_values:
+        options.append({"value": current_location_entity, "label": current_location_entity})
+
+    return selector.SelectSelector(
+        selector.SelectSelectorConfig(options=options, mode="dropdown")
+    )
+
+
+class QldFuelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[misc,call-arg]
     VERSION = 1
 
     @staticmethod
-    @callback
-    def async_get_options_flow(config_entry):
+    @callback  # type: ignore[untyped-decorator]
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> config_entries.OptionsFlow:
         """Return the options flow handler."""
         return QldFuelOptionsFlowHandler(config_entry)
 
-    async def async_step_user(self, user_input=None):
+    @staticmethod
+    def _coords_from_state(state: Any) -> tuple[float | None, float | None]:
+        """Extract latitude/longitude from a state object."""
+        if not state:
+            return None, None
+
+        lat = state.attributes.get("latitude")
+        lon = state.attributes.get("longitude")
+        if lat is None or lon is None:
+            return None, None
+
+        try:
+            return float(lat), float(lon)
+        except (TypeError, ValueError):
+            return None, None
+
+    def _resolve_location(
+        self, user_input: dict[str, Any], errors: dict[str, str]
+    ) -> tuple[float | None, float | None, str | None]:
+        """Resolve coordinates from location entity first, then zone."""
+        location_entity_id = user_input.get(LOCATION_ENTITY)
+        if location_entity_id:
+            location_state = self.hass.states.get(location_entity_id)
+            if not location_state:
+                errors[LOCATION_ENTITY] = "location_entity_not_found"
+            else:
+                lat, lon = self._coords_from_state(location_state)
+                if lat is not None and lon is not None:
+                    return lat, lon, location_state.name
+                errors[LOCATION_ENTITY] = "location_entity_missing_coordinates"
+
+        zone_id = user_input.get(ZONE)
+        zone_state = self.hass.states.get(zone_id)
+        if not zone_state:
+            errors[ZONE] = "zone_not_found"
+            return None, None, None
+
+        lat, lon = self._coords_from_state(zone_state)
+        if lat is None or lon is None:
+            errors[ZONE] = "zone_not_found"
+            return None, None, None
+
+        return lat, lon, zone_state.name
+
+    @staticmethod
+    def _build_location_unique_id(user_input: dict[str, Any], lat: float, lon: float) -> str:
+        """Build a stable unique ID for this configured location."""
+        location_entity_id = user_input.get(LOCATION_ENTITY)
+        if location_entity_id:
+            return f"location:{location_entity_id}"
+
+        zone_id = user_input.get(ZONE)
+        if zone_id:
+            return f"zone:{zone_id}"
+
+        return f"coords:{lat:.6f},{lon:.6f}"
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
         """Handle the initial setup of an instance."""
         entries = self._async_current_entries()
         master_entry = next((e for e in entries if e.data.get("is_master")), None)
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            zone_id = user_input.get("zone")
-            state = self.hass.states.get(zone_id)
-
-            if not state:
-                errors["zone"] = "zone_not_found"
-            else:
+            lat, lon, location_name = self._resolve_location(user_input, errors)
+            if lat is not None and lon is not None:
+                await self.async_set_unique_id(self._build_location_unique_id(user_input, lat, lon))
+                self._abort_if_unique_id_configured()
                 user_input["is_master"] = not bool(master_entry)
 
                 if master_entry:
                     user_input[TOKEN] = master_entry.data.get(TOKEN)
+                else:
+                    try:
+                        await async_validate_token(self.hass, user_input.get(TOKEN))
+                    except QldFuelAuthError:
+                        errors["base"] = "invalid_auth"
+                    except QldFuelConnectionError:
+                        errors["base"] = "cannot_connect"
 
-                user_input[CONF_LATITUDE] = state.attributes.get("latitude")
-                user_input[CONF_LONGITUDE] = state.attributes.get("longitude")
+                if not errors:
+                    user_input[CONF_LATITUDE] = lat
+                    user_input[CONF_LONGITUDE] = lon
 
-                title = f"Fuel near {state.name}"
-                return self.async_create_entry(title=title, data=user_input)
+                    title = f"Fuel near {location_name}"
+                    return self.async_create_entry(title=title, data=user_input)
 
         fields = {}
         if not master_entry:
             fields[vol.Required(TOKEN)] = str
 
-        fields[vol.Required("zone", default="zone.home")] = selector.EntitySelector(
+        fields[vol.Optional(LOCATION_ENTITY)] = _location_entity_selector(self.hass)
+        fields[vol.Required(ZONE, default="zone.home")] = selector.EntitySelector(
             selector.EntitySelectorConfig(domain="zone")
         )
         fields[vol.Required(RADIUS, default=5)] = selector.NumberSelector(
@@ -59,32 +174,63 @@ class QldFuelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(step_id="user", data_schema=vol.Schema(fields), errors=errors)
 
-    async def async_step_reconfigure(self, user_input=None):
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> config_entries.ConfigFlowResult:
+        """Handle flow initiated by reauthentication."""
+        self.context["entry_id"] = self._get_reauth_entry().entry_id
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Prompt for and validate a new subscriber token."""
+        errors = {}
+        if user_input is not None:
+            token = user_input.get(TOKEN)
+            try:
+                await async_validate_token(self.hass, token)
+            except QldFuelAuthError:
+                errors["base"] = "invalid_auth"
+            except QldFuelConnectionError:
+                errors["base"] = "cannot_connect"
+            else:
+                entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+                if entry:
+                    self.hass.config_entries.async_update_entry(
+                        entry,
+                        data={**entry.data, TOKEN: token},
+                    )
+                return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required(TOKEN): str}),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
         """Handle reconfiguration of an existing entry."""
         entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         entries = self._async_current_entries()
         master_entry = next((e for e in entries if e.data.get("is_master")), None)
         is_master = entry and entry.data.get("is_master", False)
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            zone_id = user_input.get("zone")
-            state = self.hass.states.get(zone_id)
-
-            if not state:
-                errors["zone"] = "zone_not_found"
-            else:
+            lat, lon, location_name = self._resolve_location(user_input, errors)
+            if lat is not None and lon is not None:
                 updates = dict(user_input)
                 updates["is_master"] = is_master
                 if not is_master and master_entry:
                     updates[TOKEN] = master_entry.data.get(TOKEN)
 
-                updates[CONF_LATITUDE] = state.attributes.get("latitude")
-                updates[CONF_LONGITUDE] = state.attributes.get("longitude")
+                updates[CONF_LATITUDE] = lat
+                updates[CONF_LONGITUDE] = lon
 
                 return self.async_update_reload_and_abort(
                     entry,
-                    title=f"Fuel near {state.name}",
+                    title=f"Fuel near {location_name}",
                     data=updates,
                 )
 
@@ -95,8 +241,13 @@ class QldFuelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if is_master:
             fields[vol.Required(TOKEN, default=data.get(TOKEN, ""))] = str
 
-        current_zone = options.get("zone", data.get("zone", "zone.home"))
-        fields[vol.Required("zone", default=current_zone)] = selector.EntitySelector(
+        current_location_entity = options.get(LOCATION_ENTITY, data.get(LOCATION_ENTITY))
+        location_entity_key = vol.Optional(LOCATION_ENTITY)
+        if current_location_entity:
+            location_entity_key = vol.Optional(LOCATION_ENTITY, default=current_location_entity)
+        fields[location_entity_key] = _location_entity_selector(self.hass, current_location_entity)
+        current_zone = options.get(ZONE, data.get(ZONE, "zone.home"))
+        fields[vol.Required(ZONE, default=current_zone)] = selector.EntitySelector(
             selector.EntitySelectorConfig(domain="zone")
         )
         fields[vol.Required(RADIUS, default=options.get(RADIUS, data.get(RADIUS, 5)))] = selector.NumberSelector(
@@ -112,25 +263,66 @@ class QldFuelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(step_id="reconfigure", data_schema=vol.Schema(fields), errors=errors)
 
 
-class QldFuelOptionsFlowHandler(config_entries.OptionsFlow):
+class QldFuelOptionsFlowHandler(config_entries.OptionsFlow):  # type: ignore[misc]
     """Handle options flow for QLD Fuel."""
 
-    def __init__(self, config_entry):
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
+        self.config_entry = config_entry
 
-    async def async_step_init(self, user_input=None):
+    @staticmethod
+    def _coords_from_state(state: Any) -> tuple[float | None, float | None]:
+        """Extract latitude/longitude from a state object."""
+        if not state:
+            return None, None
+
+        lat = state.attributes.get("latitude")
+        lon = state.attributes.get("longitude")
+        if lat is None or lon is None:
+            return None, None
+
+        try:
+            return float(lat), float(lon)
+        except (TypeError, ValueError):
+            return None, None
+
+    def _resolve_location(
+        self, user_input: dict[str, Any], errors: dict[str, str]
+    ) -> tuple[float | None, float | None]:
+        """Resolve coordinates from location entity first, then zone."""
+        location_entity_id = user_input.get(LOCATION_ENTITY)
+        if location_entity_id:
+            location_state = self.hass.states.get(location_entity_id)
+            if not location_state:
+                errors[LOCATION_ENTITY] = "location_entity_not_found"
+            else:
+                lat, lon = self._coords_from_state(location_state)
+                if lat is not None and lon is not None:
+                    return lat, lon
+                errors[LOCATION_ENTITY] = "location_entity_missing_coordinates"
+
+        zone_id = user_input.get(ZONE)
+        zone_state = self.hass.states.get(zone_id)
+        if not zone_state:
+            errors[ZONE] = "zone_not_found"
+            return None, None
+
+        lat, lon = self._coords_from_state(zone_state)
+        if lat is None or lon is None:
+            errors[ZONE] = "zone_not_found"
+            return None, None
+
+        return lat, lon
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
         """Manage zone, radius, fuel type and scan interval options."""
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            zone_id = user_input.get("zone")
-            state = self.hass.states.get(zone_id)
-
-            if not state:
-                errors["zone"] = "zone_not_found"
-            else:
-                user_input[CONF_LATITUDE] = state.attributes.get("latitude")
-                user_input[CONF_LONGITUDE] = state.attributes.get("longitude")
+            lat, lon = self._resolve_location(user_input, errors)
+            if lat is not None and lon is not None:
+                user_input[CONF_LATITUDE] = lat
+                user_input[CONF_LONGITUDE] = lon
                 return self.async_create_entry(title="", data=user_input)
 
         options = self.config_entry.options
@@ -140,7 +332,14 @@ class QldFuelOptionsFlowHandler(config_entries.OptionsFlow):
             step_id="init",
             errors=errors,
             data_schema=vol.Schema({
-                vol.Required("zone", default=options.get("zone", data.get("zone", "zone.home"))): selector.EntitySelector(
+                (
+                    vol.Optional(LOCATION_ENTITY, default=options.get(LOCATION_ENTITY, data.get(LOCATION_ENTITY)))
+                    if options.get(LOCATION_ENTITY, data.get(LOCATION_ENTITY))
+                    else vol.Optional(LOCATION_ENTITY)
+                ): _location_entity_selector(
+                    self.hass, options.get(LOCATION_ENTITY, data.get(LOCATION_ENTITY))
+                ),
+                vol.Required(ZONE, default=options.get(ZONE, data.get(ZONE, "zone.home"))): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain="zone")
                 ),
                 vol.Required(RADIUS, default=options.get(RADIUS, data.get(RADIUS, 5))): selector.NumberSelector(

--- a/custom_components/qld_fuel/const.py
+++ b/custom_components/qld_fuel/const.py
@@ -3,6 +3,8 @@ from homeassistant.const import Platform
 DOMAIN = "qld_fuel"
 
 TOKEN = "subscriber_token"
+LOCATION_ENTITY = "location_entity"
+ZONE = "zone"
 
 RADIUS = "radius"
 

--- a/custom_components/qld_fuel/coordinator.py
+++ b/custom_components/qld_fuel/coordinator.py
@@ -117,6 +117,8 @@ class QldFuelDataUpdateCoordinator(DataUpdateCoordinator):
                     "name": s_info.get("N"),
                     "address": s_info.get("A"),
                     "postcode": s_info.get("P"),
+                    "latitude": s_info.get("Lat"),
+                    "longitude": s_info.get("Lng"),
                 }
 
             price_map.setdefault(s_id, []).append(clean_price_entry)
@@ -161,12 +163,16 @@ class QldFuelDataUpdateCoordinator(DataUpdateCoordinator):
                         "name": site.get("N"),
                         "address": site.get("A"),
                         "postcode": site.get("P"),
+                        "latitude": site.get("Lat"),
+                        "longitude": site.get("Lng"),
                     }
 
             filtered_sites[s_id] = {
                 "name": site.get("N"),
                 "address": site.get("A"),
                 "postcode": site.get("P"),
+                "latitude": s_lat,
+                "longitude": s_lon,
                 "distance": round(dist, 1),
                 "prices": site_prices,
                 "stats": stats,

--- a/custom_components/qld_fuel/coordinator.py
+++ b/custom_components/qld_fuel/coordinator.py
@@ -1,23 +1,70 @@
 import logging
 import asyncio
 from datetime import timedelta
+from typing import Any
 
+from aiohttp import ClientError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.core import callback
 from homeassistant.util import dt as dt_util
 from homeassistant.util.location import distance
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 
-from .const import DOMAIN, TOKEN, RADIUS, SCAN_INTERVAL
+from .const import DOMAIN, TOKEN, RADIUS, SCAN_INTERVAL, LOCATION_ENTITY, ZONE
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class QldFuelDataUpdateCoordinator(DataUpdateCoordinator):
+class QldFuelAuthError(Exception):
+    """Raised when token authentication fails."""
+
+
+class QldFuelConnectionError(Exception):
+    """Raised when the API cannot be reached."""
+
+
+async def async_validate_token(hass: Any, token: str | None) -> None:
+    """Validate subscriber token by calling a lightweight authenticated endpoint."""
+    if not token:
+        raise QldFuelAuthError("Subscriber token is missing")
+
+    headers = {"Authorization": f"FPDAPI SubscriberToken={token}"}
+    session = async_get_clientsession(hass)
+    url = (
+        "https://fppdirectapi-prod.fuelpricesqld.com.au/"
+        "Subscriber/GetFullSiteDetails?countryId=21&geoRegionLevel=3&geoRegionId=1"
+    )
+
+    try:
+        async with asyncio.timeout(30):
+            async with session.get(url, headers=headers) as response:
+                if response.status in (401, 403):
+                    raise QldFuelAuthError(f"Auth failed with status {response.status}")
+                if response.status != 200:
+                    raise QldFuelConnectionError(f"API returned status {response.status}")
+    except asyncio.CancelledError:
+        raise
+    except (QldFuelAuthError, QldFuelConnectionError):
+        raise
+    except (ClientError, TimeoutError) as err:
+        raise QldFuelConnectionError(str(err)) from err
+    except Exception as err:
+        raise QldFuelConnectionError(str(err)) from err
+
+
+class QldFuelDataUpdateCoordinator(DataUpdateCoordinator):  # type: ignore[misc]
     """Manage fetching data; one shared API fetch is cached across all zone instances."""
 
-    def __init__(self, hass, entry):
+    def __init__(self, hass: Any, entry: Any) -> None:
         self.entry = entry
+        self._remove_location_listener = None
 
         scan_interval = entry.options.get(
             SCAN_INTERVAL, entry.data.get(SCAN_INTERVAL, 6)
@@ -30,7 +77,111 @@ class QldFuelDataUpdateCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(hours=float(scan_interval)),
         )
 
-    async def _async_update_data(self):
+    def _issue_id(self, kind: str) -> str:
+        """Build deterministic issue IDs for this config entry."""
+        return f"{self.entry.entry_id}_{kind}"
+
+    def _create_repair_issue(self, kind: str) -> None:
+        """Create a Repairs issue for actionable runtime faults."""
+        async_create_issue(
+            self.hass,
+            DOMAIN,
+            self._issue_id(kind),
+            is_fixable=(kind == "auth"),
+            severity=IssueSeverity.ERROR,
+            translation_key=f"{kind}_update_failed",
+            translation_placeholders={"entry_title": self.entry.title},
+        )
+
+    def _clear_repair_issue(self, kind: str) -> None:
+        """Clear a previously raised Repairs issue."""
+        async_delete_issue(self.hass, DOMAIN, self._issue_id(kind))
+
+    @staticmethod
+    def _coords_from_state(state: Any) -> tuple[float | None, float | None]:
+        """Extract and normalize lat/lon from an entity state."""
+        if not state:
+            return None, None
+
+        lat = state.attributes.get("latitude")
+        lon = state.attributes.get("longitude")
+        if lat is None or lon is None:
+            return None, None
+
+        try:
+            return float(lat), float(lon)
+        except (TypeError, ValueError):
+            return None, None
+
+    def _resolve_entry_coords(self) -> tuple[float | None, float | None, str | None]:
+        """Resolve coordinates from location entity, then zone, then stored values."""
+        location_entity = self.entry.options.get(
+            LOCATION_ENTITY, self.entry.data.get(LOCATION_ENTITY)
+        )
+        if location_entity:
+            location_state = self.hass.states.get(location_entity)
+            lat, lon = self._coords_from_state(location_state)
+            if lat is not None and lon is not None:
+                return lat, lon, location_entity
+
+        zone_entity = self.entry.options.get(ZONE, self.entry.data.get(ZONE))
+        if zone_entity:
+            zone_state = self.hass.states.get(zone_entity)
+            lat, lon = self._coords_from_state(zone_state)
+            if lat is not None and lon is not None:
+                return lat, lon, zone_entity
+
+        lat = self.entry.options.get(
+            CONF_LATITUDE, self.entry.data.get(CONF_LATITUDE, self.hass.config.latitude)
+        )
+        lon = self.entry.options.get(
+            CONF_LONGITUDE, self.entry.data.get(CONF_LONGITUDE, self.hass.config.longitude)
+        )
+        try:
+            return float(lat), float(lon), None
+        except (TypeError, ValueError):
+            return None, None, None
+
+    async def async_setup_location_listener(self) -> None:
+        """Track location entity changes and recompute local derived data from cache."""
+        if self._remove_location_listener is not None:
+            return
+
+        location_entity = self.entry.options.get(
+            LOCATION_ENTITY, self.entry.data.get(LOCATION_ENTITY)
+        )
+        if not location_entity:
+            return
+
+        def _location_changed(event: Any) -> None:
+            new_state = event.data.get("new_state")
+            old_state = event.data.get("old_state")
+            new_lat, new_lon = self._coords_from_state(new_state)
+            old_lat, old_lon = self._coords_from_state(old_state)
+            if (new_lat, new_lon) == (old_lat, old_lon):
+                return
+            self.hass.async_create_task(self.async_recompute_from_cache())
+
+        self._remove_location_listener = async_track_state_change_event(
+            self.hass,
+            [location_entity],
+            _location_changed,
+        )
+
+    async def async_recompute_from_cache(self) -> None:
+        """Recompute derived local data only, using cached API payload."""
+        raw_data = self.hass.data.get(DOMAIN, {}).get("raw_data")
+        if not raw_data:
+            return
+        self.async_set_updated_data(self._process_raw_data(raw_data))
+
+    async def async_shutdown(self) -> None:
+        """Remove listeners on unload."""
+        if self._remove_location_listener is not None:
+            self._remove_location_listener()
+            self._remove_location_listener = None
+
+    async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API or use shared cache."""
         domain_data = self.hass.data[DOMAIN]
 
@@ -47,6 +198,18 @@ class QldFuelDataUpdateCoordinator(DataUpdateCoordinator):
                     raw_data = await self._fetch_from_api()
                     domain_data["raw_data"] = raw_data
                     domain_data["last_fetch_time"] = now
+                    self._clear_repair_issue("auth")
+                    self._clear_repair_issue("connectivity")
+                except QldFuelAuthError as err:
+                    self._create_repair_issue("auth")
+                    raise UpdateFailed(f"Authentication failed: {err}") from err
+                except QldFuelConnectionError as err:
+                    self._create_repair_issue("connectivity")
+                    raise UpdateFailed(f"Error communicating with API: {err}") from err
+                except asyncio.CancelledError:
+                    raise
+                except (ClientError, TimeoutError, TypeError, ValueError, KeyError) as err:
+                    raise UpdateFailed(f"Error communicating with API: {err}") from err
                 except Exception as err:
                     raise UpdateFailed(f"Error communicating with API: {err}") from err
             else:
@@ -56,7 +219,7 @@ class QldFuelDataUpdateCoordinator(DataUpdateCoordinator):
 
         return self._process_raw_data(raw_data)
 
-    async def _fetch_from_api(self):
+    async def _fetch_from_api(self) -> dict[str, list[dict[str, Any]]]:
         """Perform the actual HTTP requests to the QLD Fuel API."""
         token = self.entry.data.get(TOKEN)
         if not token:
@@ -75,9 +238,12 @@ class QldFuelDataUpdateCoordinator(DataUpdateCoordinator):
             results = []
             for url in urls:
                 async with session.get(url, headers=headers) as response:
+                    if response.status in (401, 403):
+                        _LOGGER.error("QLD Fuel API authentication failed with status %s", response.status)
+                        raise QldFuelAuthError(f"API auth error {response.status}")
                     if response.status != 200:
                         _LOGGER.error("QLD Fuel API returned status %s", response.status)
-                        raise UpdateFailed(f"API Error {response.status}")
+                        raise QldFuelConnectionError(f"API Error {response.status}")
                     results.append(await response.json())
 
             return {
@@ -85,21 +251,23 @@ class QldFuelDataUpdateCoordinator(DataUpdateCoordinator):
                 "prices": results[1].get("SitePrices", []),
             }
 
-    def _process_raw_data(self, raw_data):
+    def _process_raw_data(self, raw_data: dict[str, Any]) -> dict[str, Any]:
         """Transform raw JSON into the structured dict used by sensors."""
         raw_sites = raw_data.get("sites", [])
         raw_prices = raw_data.get("prices", [])
 
         site_lookup = {str(s["S"]): s for s in raw_sites}
-        price_map = {}
-        global_cheapest = {}
+        price_map: dict[str, list[dict[str, Any]]] = {}
+        global_cheapest: dict[str, dict[str, Any]] = {}
 
         for p in raw_prices:
             price_raw = p.get("Price")
             if price_raw is None or not (1 < price_raw < 9990):
                 continue
 
-            display_price = float(price_raw) / 10.0
+            # Normalize to a single decimal place to avoid floating-point noise
+            # showing up in recorder graphs (e.g. 244.89999999999998).
+            display_price = round(float(price_raw) / 10.0, 1)
             f_id = str(p.get("FuelId"))
             s_id = str(p.get("SiteId"))
 
@@ -125,13 +293,23 @@ class QldFuelDataUpdateCoordinator(DataUpdateCoordinator):
 
         return self._filter_to_zone(raw_sites, price_map, global_cheapest)
 
-    def _filter_to_zone(self, sites, price_map, global_cheapest):
+    def _filter_to_zone(
+        self,
+        sites: list[dict[str, Any]],
+        price_map: dict[str, list[dict[str, Any]]],
+        global_cheapest: dict[str, dict[str, Any]],
+    ) -> dict[str, Any]:
         """Filter stations within this entry's defined radius."""
         filtered_sites = {}
-        local_cheapest = {}
+        local_cheapest: dict[str, dict[str, Any]] = {}
 
-        lat = self.entry.options.get(CONF_LATITUDE, self.entry.data.get(CONF_LATITUDE, self.hass.config.latitude))
-        lon = self.entry.options.get(CONF_LONGITUDE, self.entry.data.get(CONF_LONGITUDE, self.hass.config.longitude))
+        lat, lon, _ = self._resolve_entry_coords()
+        if lat is None or lon is None:
+            return {
+                "sites": {},
+                "global_cheapest": global_cheapest,
+                "local_cheapest": {},
+            }
         radius = float(self.entry.options.get(RADIUS, self.entry.data.get(RADIUS, 5)))
 
         for site in sites:

--- a/custom_components/qld_fuel/diagnostics.py
+++ b/custom_components/qld_fuel/diagnostics.py
@@ -1,0 +1,123 @@
+"""Diagnostics support for the QLD Fuel integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN, TOKEN
+from .coordinator import QldFuelDataUpdateCoordinator
+
+_REDACT_CONFIG_KEYS = {TOKEN}
+_REDACT_PAYLOAD_KEYS = {
+    "Authorization",
+    "authorization",
+    "subscriber_token",
+    "SubscriberToken",
+    "token",
+    "api_key",
+    "password",
+    "passwd",
+    "client_secret",
+}
+
+
+def _snapshot_sites(raw_sites: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return a compact, sanitized snapshot of raw site payload."""
+    preview = []
+    for site in raw_sites[:5]:
+        preview.append(
+            {
+                "S": site.get("S"),
+                "N": site.get("N"),
+                "P": site.get("P"),
+                "Lat": site.get("Lat"),
+                "Lng": site.get("Lng"),
+            }
+        )
+    return {"count": len(raw_sites), "preview": preview}
+
+
+def _snapshot_prices(raw_prices: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return a compact, sanitized snapshot of raw prices payload."""
+    preview = []
+    for price in raw_prices[:10]:
+        preview.append(
+            {
+                "FuelId": price.get("FuelId"),
+                "SiteId": price.get("SiteId"),
+                "Price": price.get("Price"),
+                "T": price.get("T"),
+            }
+        )
+    return {"count": len(raw_prices), "preview": preview}
+
+
+def _sanitize_raw_payload(raw_data: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Sanitize cached API payload while keeping useful troubleshooting context."""
+    if not raw_data:
+        return None
+
+    sites = raw_data.get("sites", [])
+    prices = raw_data.get("prices", [])
+    snapshot = {
+        "sites": _snapshot_sites(sites if isinstance(sites, list) else []),
+        "prices": _snapshot_prices(prices if isinstance(prices, list) else []),
+    }
+    redacted = async_redact_data(snapshot, _REDACT_PAYLOAD_KEYS)
+    return redacted if isinstance(redacted, dict) else {}
+
+
+def _sanitize_processed_payload(data: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Sanitize processed coordinator data to avoid full payload dumps."""
+    if not data:
+        return None
+
+    sites = data.get("sites", {})
+    global_cheapest = data.get("global_cheapest", {})
+    local_cheapest = data.get("local_cheapest", {})
+
+    sample_site_ids = list(sites.keys())[:5] if isinstance(sites, dict) else []
+    sample_global_fuels = list(global_cheapest.keys())[:10] if isinstance(global_cheapest, dict) else []
+    sample_local_fuels = list(local_cheapest.keys())[:10] if isinstance(local_cheapest, dict) else []
+
+    snapshot: dict[str, Any] = {
+        "sites_count": len(sites) if isinstance(sites, dict) else 0,
+        "sample_site_ids": sample_site_ids,
+        "global_cheapest_fuel_ids": sample_global_fuels,
+        "local_cheapest_fuel_ids": sample_local_fuels,
+    }
+    redacted = async_redact_data(snapshot, _REDACT_PAYLOAD_KEYS)
+    return redacted if isinstance(redacted, dict) else {}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    domain_data = hass.data.get(DOMAIN, {})
+    coordinator = entry.runtime_data
+
+    coordinator_payload: dict[str, Any] | None = None
+    if isinstance(coordinator, QldFuelDataUpdateCoordinator):
+        coordinator_payload = coordinator.data
+
+    return {
+        "entry": {
+            "entry_id": entry.entry_id,
+            "title": entry.title,
+            "data": async_redact_data(dict(entry.data), _REDACT_CONFIG_KEYS),
+            "options": async_redact_data(dict(entry.options), _REDACT_CONFIG_KEYS),
+        },
+        "cache": {
+            "last_fetch_time": domain_data.get("last_fetch_time"),
+            "raw_payload_snapshot": _sanitize_raw_payload(domain_data.get("raw_data")),
+        },
+        "coordinator": {
+            "loaded": isinstance(coordinator, QldFuelDataUpdateCoordinator),
+            "payload_snapshot": _sanitize_processed_payload(coordinator_payload),
+        },
+    }

--- a/custom_components/qld_fuel/icons.json
+++ b/custom_components/qld_fuel/icons.json
@@ -1,0 +1,24 @@
+{
+    "entity": {
+        "sensor": {
+            "best_price_global": {
+                "default": "mdi:star-circle"
+            },
+            "best_price_all_tracked": {
+                "default": "mdi:star-circle"
+            },
+            "best_price_nearby": {
+                "default": "mdi:star-circle"
+            },
+            "best_price_local": {
+                "default": "mdi:star-circle"
+            },
+            "station_fuel_price": {
+                "default": "mdi:gas-station"
+            },
+            "last_api_response": {
+                "default": "mdi:cloud-check-outline"
+            }
+        }
+    }
+}

--- a/custom_components/qld_fuel/sensor.py
+++ b/custom_components/qld_fuel/sensor.py
@@ -169,6 +169,9 @@ class QldFuelBestPriceSensor(CoordinatorEntity, SensorEntity):
         return {
             "station_name": site_raw.get("N", "Unknown"),
             "address": f"{site_raw.get('A', '')} {site_raw.get('P', '')}".strip(),
+            "latitude": s_lat,
+            "longitude": s_lon,
+            "Location": f"{s_lat}, {s_lon}",
             "distance_km": dist_km,
         }
 
@@ -224,10 +227,14 @@ class FuelPriceSensor(CoordinatorEntity, SensorEntity):
 
         attrs = {
             "address": f"{site.get('address')} {site.get('postcode')}".strip(),
+            "latitude": site.get("latitude"),
+            "longitude": site.get("longitude"),
             "distance": f"{site.get('distance')} km",
             "fuel_id": self.fuel_id,
             "difference_to_qld_cheapest": stats.get("qld_delta", 0),
         }
+        if site.get("latitude") is not None and site.get("longitude") is not None:
+            attrs["Location"] = f"{site.get('latitude')}, {site.get('longitude')}"
 
         if self._7d_low is not None:
             attrs.update({

--- a/custom_components/qld_fuel/sensor.py
+++ b/custom_components/qld_fuel/sensor.py
@@ -1,37 +1,55 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
+from typing import Any
 
 from homeassistant.components.recorder import history, get_instance
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
-from homeassistant.core import callback
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 from homeassistant.util.location import distance
 
-from .const import DOMAIN, FUEL_TYPES, FUEL_TYPES_OPTIONS
+try:
+    from homeassistant.config_entries import ConfigEntry
+except ImportError:  # pragma: no cover - allows lightweight test stubs
+    ConfigEntry = Any
+
+try:
+    from homeassistant.core import HomeAssistant
+except ImportError:  # pragma: no cover - allows lightweight test stubs
+    HomeAssistant = Any
+
+try:
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+except ImportError:  # pragma: no cover - allows lightweight test stubs
+    AddEntitiesCallback = Any
+
+from .const import DOMAIN, FUEL_TYPES, FUEL_TYPES_OPTIONS, LOCATION_ENTITY, RADIUS
 
 _LOGGER = logging.getLogger(__name__)
 
-_RESERVED_DOMAIN_KEYS = {"raw_data", "last_fetch_time", "fetch_lock", "master_entry_id"}
+PARALLEL_UPDATES = 1
 
-
-def get_fuel_data(data_dict, f_id):
+def get_fuel_data(
+    data_dict: dict[str, dict[str, Any]] | None, f_id: str
+) -> dict[str, Any] | None:
     """Helper to find fuel data by string fuel ID."""
     if not data_dict:
         return None
     return data_dict.get(str(f_id))
 
 
-def _find_all_tracked_best(hass, fuel_id):
+def _find_all_tracked_best(
+    hass: HomeAssistant, fuel_id: str
+) -> tuple[float | None, dict[str, Any] | None]:
     """Return the cheapest local price and its station data across all tracked zones."""
     best_price = None
     best_station = None
-    for key, coord in hass.data.get(DOMAIN, {}).items():
-        if key in _RESERVED_DOMAIN_KEYS:
-            continue
-        if hasattr(coord, "data") and coord.data:
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        coord = entry.runtime_data
+        if getattr(coord, "data", None):
             local_best = get_fuel_data(coord.data.get("local_cheapest"), fuel_id)
             if local_best and local_best.get("price") is not None:
                 price = float(local_best["price"])
@@ -41,15 +59,38 @@ def _find_all_tracked_best(hass, fuel_id):
     return best_price, best_station
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+def _resolve_location_source(entry: ConfigEntry) -> str | None:
+    """Return the configured location source entity for derived nearby sensors."""
+    value = entry.options.get(LOCATION_ENTITY, entry.data.get(LOCATION_ENTITY))
+    return value if isinstance(value, str) else None
+
+
+def _remove_stale_entities(
+    hass: HomeAssistant, entry: ConfigEntry, active_unique_ids: set[str]
+) -> None:
+    """Remove stale per-entry station entities from the entity registry."""
+    entity_registry = er.async_get(hass)
+    for registry_entry in er.async_entries_for_config_entry(entity_registry, entry.entry_id):
+        unique_id = getattr(registry_entry, "unique_id", None)
+        if not unique_id:
+            continue
+        if not unique_id.startswith(f"{DOMAIN}_{entry.entry_id}_"):
+            continue
+        if unique_id not in active_unique_ids:
+            entity_registry.async_remove(registry_entry.entity_id)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
     """Set up the fuel sensors for this specific entry."""
-    domain_data = hass.data[DOMAIN]
-    coordinator = domain_data[entry.entry_id]
+    coordinator = entry.runtime_data
     entities = []
+    active_unique_ids = set()
 
     is_master = (
         entry.data.get("is_master", False)
-        or domain_data.get("master_entry_id") == entry.entry_id
+        or hass.data[DOMAIN].get("master_entry_id") == entry.entry_id
     )
     chosen_fuels = entry.options.get(FUEL_TYPES, entry.data.get(FUEL_TYPES, []))
 
@@ -61,26 +102,44 @@ async def async_setup_entry(hass, entry, async_add_entities):
         for price_info in site_data["prices"]:
             f_id = str(price_info.get("FuelId"))
             if f_id in chosen_fuels:
-                entities.append(FuelPriceSensor(coordinator, site_id, f_id))
+                entity = FuelPriceSensor(coordinator, site_id, f_id)
+                entities.append(entity)
+                active_unique_ids.add(entity._attr_unique_id)
 
     if is_master:
         for f_id in chosen_fuels:
-            entities.append(QldFuelBestPriceSensor(coordinator, f_id, "global"))
-            entities.append(QldFuelBestPriceSensor(coordinator, f_id, "all_tracked"))
+            global_entity = QldFuelBestPriceSensor(coordinator, f_id, "global")
+            tracked_entity = QldFuelBestPriceSensor(coordinator, f_id, "all_tracked")
+            entities.append(global_entity)
+            entities.append(tracked_entity)
+            active_unique_ids.add(global_entity._attr_unique_id)
+            active_unique_ids.add(tracked_entity._attr_unique_id)
 
     for f_id in chosen_fuels:
-        entities.append(QldFuelBestPriceSensor(coordinator, f_id, "local"))
+        local_entity = QldFuelBestPriceSensor(coordinator, f_id, "local")
+        nearby_entity = QldFuelBestPriceSensor(coordinator, f_id, "nearby")
+        entities.append(local_entity)
+        entities.append(nearby_entity)
+        active_unique_ids.add(local_entity._attr_unique_id)
+        active_unique_ids.add(nearby_entity._attr_unique_id)
 
+    api_diag = QldFuelLastApiResponseSensor(coordinator)
+    entities.append(api_diag)
+    active_unique_ids.add(api_diag._attr_unique_id)
+
+    _remove_stale_entities(hass, entry, active_unique_ids)
     async_add_entities(entities)
 
 
-class QldFuelBestPriceSensor(CoordinatorEntity, SensorEntity):
+class QldFuelBestPriceSensor(CoordinatorEntity, SensorEntity):  # type: ignore[misc]
     """Sensor for reporting best prices (Global, Local, or All Tracked)."""
 
+    _attr_has_entity_name = True
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "¢/L"
+    _attr_device_class = None
 
-    def __init__(self, coordinator, fuel_id, scope):
+    def __init__(self, coordinator: Any, fuel_id: str, scope: str) -> None:
         super().__init__(coordinator)
         self.fuel_id = fuel_id
         self.scope = scope
@@ -93,6 +152,11 @@ class QldFuelBestPriceSensor(CoordinatorEntity, SensorEntity):
         elif scope == "all_tracked":
             self._attr_name = f"Best {fuel_info['label']} in Tracked Areas"
             self._attr_unique_id = f"{DOMAIN}_tracked_{fuel_id}"
+        elif scope == "nearby":
+            # Keep the entity name concise to avoid duplicated object IDs when
+            # Home Assistant prefixes the device name.
+            self._attr_name = f"Best {fuel_info['label']}"
+            self._attr_unique_id = f"{DOMAIN}_nearby_{coordinator.entry.entry_id}_{fuel_id}"
         else:
             zone_id = coordinator.entry.data.get("zone", "zone.home")
             state = coordinator.hass.states.get(zone_id)
@@ -100,7 +164,26 @@ class QldFuelBestPriceSensor(CoordinatorEntity, SensorEntity):
             self._attr_name = f"{fuel_info['label']} ({zone_name})"
             self._attr_unique_id = f"{DOMAIN}_local_{coordinator.entry.entry_id}_{fuel_id}"
 
-        self._attr_icon = "mdi:star-circle"
+        if scope == "global":
+            self._attr_translation_key = "best_price_global"
+        elif scope == "all_tracked":
+            self._attr_translation_key = "best_price_all_tracked"
+        elif scope == "nearby":
+            self._attr_translation_key = "best_price_nearby"
+        else:
+            self._attr_translation_key = "best_price_local"
+        self._attr_entity_category = (
+            EntityCategory.DIAGNOSTIC
+            if scope in ("global", "all_tracked")
+            else None
+        )
+        # Keep nearby sensors as the primary surfaced entity and leave the
+        # legacy local sensor opt-in for new installs.
+        self._attr_entity_registry_enabled_default = scope not in (
+            "global",
+            "all_tracked",
+            "local",
+        )
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -122,28 +205,64 @@ class QldFuelBestPriceSensor(CoordinatorEntity, SensorEntity):
         )
 
     @property
-    def native_value(self):
+    def native_value(self) -> float | None:
+        def _rounded_price(value: Any) -> float | None:
+            if value is None:
+                return None
+            try:
+                return round(float(value), 1)
+            except (TypeError, ValueError):
+                return None
+
         if self.scope == "global":
             data = get_fuel_data(self.coordinator.data.get("global_cheapest"), self.fuel_id)
-            return data.get("price") if data else None
+            return _rounded_price(data.get("price")) if data else None
 
         if self.scope == "all_tracked":
             best_price, _ = _find_all_tracked_best(self.hass, self.fuel_id)
-            return best_price
+            return round(float(best_price), 1) if best_price is not None else None
 
         data = get_fuel_data(self.coordinator.data.get("local_cheapest"), self.fuel_id)
-        return data.get("price") if data else None
+        return _rounded_price(data.get("price")) if data else None
+
+    def _find_station_entity_id(self, station_data: dict[str, Any]) -> str | None:
+        """Best-effort lookup of the station sensor entity id."""
+        site_id = station_data.get("site_id")
+        if site_id is None:
+            return None
+
+        entity_registry = er.async_get(self.hass)
+        target_unique_id = (
+            f"{DOMAIN}_{self.coordinator.entry.entry_id}_{self.fuel_id}_{site_id}"
+        )
+        entity_id = entity_registry.async_get_entity_id(
+            "sensor",
+            DOMAIN,
+            target_unique_id,
+        )
+        return entity_id if isinstance(entity_id, str) else None
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any]:
         if self.scope == "global":
             station_data = get_fuel_data(self.coordinator.data.get("global_cheapest"), self.fuel_id)
-        elif self.scope == "local":
+        elif self.scope in ("local", "nearby"):
             station_data = get_fuel_data(self.coordinator.data.get("local_cheapest"), self.fuel_id)
         else:
             _, station_data = _find_all_tracked_best(self.hass, self.fuel_id)
 
         if not station_data:
+            if self.scope == "nearby":
+                return {
+                    "fuel_id": self.fuel_id,
+                    "search_radius_km": float(
+                        self.coordinator.entry.options.get(
+                            RADIUS, self.coordinator.entry.data.get(RADIUS, 5)
+                        )
+                    ),
+                    "source_tracker": _resolve_location_source(self.coordinator.entry),
+                    "reason": "no_stations_in_range",
+                }
             return {"status": f"No data for fuel_id {self.fuel_id} in {self.scope}"}
 
         site_id = station_data.get("site_id")
@@ -157,8 +276,7 @@ class QldFuelBestPriceSensor(CoordinatorEntity, SensorEntity):
         if not site_raw:
             return {"status": f"Site {site_id} not found in raw data"}
 
-        h_lat = self.coordinator.entry.options.get(CONF_LATITUDE, self.coordinator.entry.data.get(CONF_LATITUDE))
-        h_lon = self.coordinator.entry.options.get(CONF_LONGITUDE, self.coordinator.entry.data.get(CONF_LONGITUDE))
+        h_lat, h_lon, _ = self.coordinator._resolve_entry_coords()
         s_lat = float(site_raw.get("Lat", 0))
         s_lon = float(site_raw.get("Lng", 0))
 
@@ -166,7 +284,7 @@ class QldFuelBestPriceSensor(CoordinatorEntity, SensorEntity):
         if h_lat and h_lon and s_lat != 0:
             dist_km = round(distance(h_lat, h_lon, s_lat, s_lon) / 1000, 1)
 
-        return {
+        attrs = {
             "station_name": site_raw.get("N", "Unknown"),
             "address": f"{site_raw.get('A', '')} {site_raw.get('P', '')}".strip(),
             "latitude": s_lat,
@@ -174,26 +292,81 @@ class QldFuelBestPriceSensor(CoordinatorEntity, SensorEntity):
             "Location": f"{s_lat}, {s_lon}",
             "distance_km": dist_km,
         }
+        if self.scope == "nearby":
+            source_entity = _resolve_location_source(self.coordinator.entry)
+            attrs.update(
+                {
+                    "search_radius_km": float(
+                        self.coordinator.entry.options.get(
+                            RADIUS, self.coordinator.entry.data.get(RADIUS, 5)
+                        )
+                    ),
+                    "source_tracker": source_entity,
+                    "station_entity_id": self._find_station_entity_id(station_data),
+                    "reason": "ok",
+                }
+            )
+        return attrs
 
 
-class FuelPriceSensor(CoordinatorEntity, SensorEntity):
+class QldFuelLastApiResponseSensor(CoordinatorEntity, SensorEntity):  # type: ignore[misc]
+    """Diagnostic: when the shared QLD Fuel API last returned fresh data."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_translation_key = "last_api_response"
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: Any) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = (
+            f"{DOMAIN}_{coordinator.entry.entry_id}_last_api_response"
+        )
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"zone_{self.coordinator.entry.entry_id}")},
+            name=self.coordinator.entry.title,
+            manufacturer="QLD Fuel API",
+            model="Local Zone Monitor",
+            entry_type=DeviceEntryType.SERVICE,
+        )
+
+    @property
+    def native_value(self) -> datetime | None:
+        domain_data = self.hass.data.get(DOMAIN, {})
+        ts = domain_data.get("last_fetch_time")
+        return ts if isinstance(ts, datetime) else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return {
+            "last_update_success": self.coordinator.last_update_success,
+        }
+
+
+class FuelPriceSensor(CoordinatorEntity, SensorEntity):  # type: ignore[misc]
     """Representation of a specific station's Fuel Price Sensor."""
 
+    _attr_has_entity_name = True
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "¢/L"
+    _attr_device_class = None
 
-    def __init__(self, coordinator, site_id, fuel_id):
+    def __init__(self, coordinator: Any, site_id: str, fuel_id: str) -> None:
         super().__init__(coordinator)
         self.site_id = site_id
         self.fuel_id = fuel_id
-        self._attr_icon = "mdi:gas-station"
+        self._attr_translation_key = "station_fuel_price"
 
-        self._14d_low = None
-        self._14d_low_days = None
-        self._14d_avg = None
-        self._7d_low = None
-        self._7d_low_days = None
-        self._7d_avg = None
+        self._14d_low: float | None = None
+        self._14d_low_days: int | None = None
+        self._14d_avg: float | None = None
+        self._7d_low: float | None = None
+        self._7d_low_days: int | None = None
+        self._7d_avg: float | None = None
 
         fuel_info = next((f for f in FUEL_TYPES_OPTIONS if f["value"] == fuel_id), {"label": fuel_id})
         site = coordinator.data.get("sites", {}).get(site_id)
@@ -213,15 +386,16 @@ class FuelPriceSensor(CoordinatorEntity, SensorEntity):
         )
 
     @property
-    def native_value(self):
+    def native_value(self) -> float | None:
         site_data = self.coordinator.data.get("sites", {}).get(self.site_id, {})
         for p in site_data.get("prices", []):
             if str(p.get("FuelId")) == self.fuel_id:
-                return p.get("Price")
+                value = p.get("Price")
+                return float(value) if value is not None else None
         return None
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any]:
         site = self.coordinator.data.get("sites", {}).get(self.site_id, {})
         stats = site.get("stats", {}).get(self.fuel_id, {})
 
@@ -250,16 +424,15 @@ class FuelPriceSensor(CoordinatorEntity, SensorEntity):
             })
         return attrs
 
-    async def async_added_to_hass(self):
+    async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
         await self._update_history()
 
-    @callback
     def _handle_coordinator_update(self) -> None:
         self.hass.async_create_task(self._update_history())
         super()._handle_coordinator_update()
 
-    async def _update_history(self):
+    async def _update_history(self) -> None:
         """Query the recorder for historical lows and averages."""
         if self.hass.is_stopping:
             return

--- a/custom_components/qld_fuel/strings.json
+++ b/custom_components/qld_fuel/strings.json
@@ -5,6 +5,7 @@
                 "title": "QLD Fuel Setup",
                 "description": "Configure the stations and fuels to track. All instances are based on a Home Assistant Zone.",
                 "data": {
+                    "location_entity": "Tracked Location Source",
                     "zone": "Home Assistant Zone",
                     "subscriber_token": "Data Consumer Token",
                     "radius": "Fuel Station Radius (km)",
@@ -16,16 +17,31 @@
                 "title": "Reconfigure QLD Fuel",
                 "description": "Update the zone, radius, fuel types, or update interval for this instance.",
                 "data": {
+                    "location_entity": "Tracked Location Source",
                     "zone": "Home Assistant Zone",
                     "subscriber_token": "Data Consumer Token",
                     "radius": "Fuel Station Radius (km)",
                     "fuel_types": "Fuel Types to Track",
                     "scan_interval": "Update Interval (hours)"
                 }
+            },
+            "reauth_confirm": {
+                "title": "Reconnect Queensland Fuel Prices",
+                "description": "Your data consumer token needs to be re-authenticated.",
+                "data": {
+                    "subscriber_token": "Data Consumer Token"
+                }
             }
         },
+        "abort": {
+            "reauth_successful": "Re-authentication was successful."
+        },
         "error": {
-            "zone_not_found": "The selected zone could not be found. Please choose a valid Home Assistant Zone."
+            "zone_not_found": "The selected zone could not be found. Please choose a valid Home Assistant Zone.",
+            "location_entity_not_found": "The selected location entity could not be found.",
+            "location_entity_missing_coordinates": "The selected location entity does not provide latitude and longitude attributes.",
+            "invalid_auth": "Invalid data consumer token.",
+            "cannot_connect": "Failed to connect to the Queensland Fuel Prices API."
         }
     },
     "options": {
@@ -33,6 +49,7 @@
             "init": {
                 "title": "QLD Fuel Options",
                 "data": {
+                    "location_entity": "Tracked Location Source",
                     "zone": "Home Assistant Zone",
                     "radius": "Fuel Station Radius (km)",
                     "fuel_types": "Fuel Types to Track",
@@ -41,7 +58,26 @@
             }
         },
         "error": {
-            "zone_not_found": "The selected zone could not be found. Please choose a valid Home Assistant Zone."
+            "zone_not_found": "The selected zone could not be found. Please choose a valid Home Assistant Zone.",
+            "location_entity_not_found": "The selected location entity could not be found.",
+            "location_entity_missing_coordinates": "The selected location entity does not provide latitude and longitude attributes."
+        }
+    },
+    "issues": {
+        "auth_update_failed": {
+            "title": "Authentication failed for {entry_title}",
+            "description": "The configured data consumer token is no longer accepted by the Queensland Fuel Prices API. Reauthenticate this integration entry."
+        },
+        "connectivity_update_failed": {
+            "title": "Connectivity issue for {entry_title}",
+            "description": "The integration could not reach the Queensland Fuel Prices API. Check connectivity and retry."
+        }
+    },
+    "entity": {
+        "sensor": {
+            "last_api_response": {
+                "name": "Last API response"
+            }
         }
     }
 }

--- a/custom_components/qld_fuel/translations/en.json
+++ b/custom_components/qld_fuel/translations/en.json
@@ -5,6 +5,7 @@
                 "title": "QLD Fuel Setup",
                 "description": "Configure the stations and fuels to track. All instances are based on a Home Assistant Zone.",
                 "data": {
+                    "location_entity": "Tracked Location Source",
                     "zone": "Home Assistant Zone",
                     "subscriber_token": "Data Consumer Token",
                     "radius": "Fuel Station Radius (km)",
@@ -16,16 +17,31 @@
                 "title": "Reconfigure QLD Fuel",
                 "description": "Update the zone, radius, fuel types, or update interval for this instance.",
                 "data": {
+                    "location_entity": "Tracked Location Source",
                     "zone": "Home Assistant Zone",
                     "subscriber_token": "Data Consumer Token",
                     "radius": "Fuel Station Radius (km)",
                     "fuel_types": "Fuel Types to Track",
                     "scan_interval": "Update Interval (hours)"
                 }
+            },
+            "reauth_confirm": {
+                "title": "Reconnect Queensland Fuel Prices",
+                "description": "Your data consumer token needs to be re-authenticated.",
+                "data": {
+                    "subscriber_token": "Data Consumer Token"
+                }
             }
         },
+        "abort": {
+            "reauth_successful": "Re-authentication was successful."
+        },
         "error": {
-            "zone_not_found": "The selected zone could not be found. Please choose a valid Home Assistant Zone."
+            "zone_not_found": "The selected zone could not be found. Please choose a valid Home Assistant Zone.",
+            "location_entity_not_found": "The selected location entity could not be found.",
+            "location_entity_missing_coordinates": "The selected location entity does not provide latitude and longitude attributes.",
+            "invalid_auth": "Invalid data consumer token.",
+            "cannot_connect": "Failed to connect to the Queensland Fuel Prices API."
         }
     },
     "options": {
@@ -33,6 +49,7 @@
             "init": {
                 "title": "QLD Fuel Options",
                 "data": {
+                    "location_entity": "Tracked Location Source",
                     "zone": "Home Assistant Zone",
                     "radius": "Fuel Station Radius (km)",
                     "fuel_types": "Fuel Types to Track",
@@ -41,7 +58,26 @@
             }
         },
         "error": {
-            "zone_not_found": "The selected zone could not be found. Please choose a valid Home Assistant Zone."
+            "zone_not_found": "The selected zone could not be found. Please choose a valid Home Assistant Zone.",
+            "location_entity_not_found": "The selected location entity could not be found.",
+            "location_entity_missing_coordinates": "The selected location entity does not provide latitude and longitude attributes."
+        }
+    },
+    "issues": {
+        "auth_update_failed": {
+            "title": "Authentication failed for {entry_title}",
+            "description": "The configured data consumer token is no longer accepted by the Queensland Fuel Prices API. Reauthenticate this integration entry."
+        },
+        "connectivity_update_failed": {
+            "title": "Connectivity issue for {entry_title}",
+            "description": "The integration could not reach the Queensland Fuel Prices API. Check connectivity and retry."
+        }
+    },
+    "entity": {
+        "sensor": {
+            "last_api_response": {
+                "name": "Last API response"
+            }
         }
     }
 }

--- a/docs/fuel-prices-qld-api-reference.md
+++ b/docs/fuel-prices-qld-api-reference.md
@@ -1,0 +1,139 @@
+# Fuel Prices QLD API Reference
+
+API version: `v1.6`  
+Publisher and Data Consumer Guide date: March 2023
+
+## Official sources
+
+This repository document is a developer-friendly reference for contributors.
+Use the official Fuel Prices QLD resources as the source of truth:
+
+- Developer portal: <https://www.fuelpricesqld.com.au/#developers>
+- Postman collection (PROD): <https://www.fuelpricesqld.com.au/documents/postmanv1.json>
+- Swagger (PROD): <https://fppdirectapi-prod.fuelpricesqld.com.au/swagger/>
+
+## Overview
+
+The Queensland Government Fuel Price Reporting scheme requires fuel retailers in Queensland to report bowser price changes within 30 minutes.
+
+Fuel Prices QLD (the Aggregator) provides this data to approved Data Consumers via a server-to-server API called **Fuel Prices QLD Direct API (OUT)**.
+
+This guide is a cleaned and reformatted API reference based on the published v1.6 documentation and cross-checked against the published Postman collection.
+
+## Key Terms
+
+- **Data Consumer**: Entity licensed to access Fuel Prices QLD data.
+- **Token / Data Consumer Token**: Subscriber credential (GUID) used to authenticate API calls.
+- **Fuel Prices QLD Direct API (OUT)**: Server API providing site, region, fuel-type, and price data.
+
+## Environments
+
+- **Integration**: For development/testing only (non-live test data).
+- **Production**: Live data for production systems.
+
+## Protocol and Authentication
+
+- All requests must use **HTTPS**.
+- Include `Authorization: FPDAPI SubscriberToken=<DATA_CONSUMER_TOKEN>` on all requests.
+- `Content-Type: application/json` is used in official Postman examples, including `GET` requests.
+
+Token format is a GUID, for example:
+
+```text
+2FEB37D3-4326-4E30-8705-0FCE0519B6D
+```
+
+## Common HTTP Response Codes
+
+- `200` OK
+- `400` Bad Request (invalid parameter values/types)
+- `401` Unauthorized (invalid or missing token)
+- `403` Forbidden
+- `404` Not Found
+- `500` Internal Server Error
+
+Always validate HTTP status before consuming response data.
+
+## JSON Compatibility Guidance
+
+Responses are JSON and may evolve in non-breaking ways:
+
+- Fields may be added at any time.
+- Field order may change.
+
+Do not rely on JSON property order in your parser.
+
+## API Methods
+
+Country value used in examples:
+
+- `countryId=21` for Australia
+
+### 1) GetBrands
+
+- **Method**: `GET`
+- **Path**: `/Subscriber/GetCountryBrands`
+- **Query params**: `countryId` (required, int)
+- **Purpose**: Returns available fuel brands.
+- **Recommended load**: Call once per day and cache locally.
+
+### 2) GetCountryGeographicRegions
+
+- **Method**: `GET`
+- **Path**: `/Subscriber/GetCountryGeographicRegions`
+- **Query params**: `countryId` (required, int)
+- **Purpose**: Returns a flattened region hierarchy.
+- **Recommended load**: Call once per day and cache locally.
+
+### 3) GetFuelTypes
+
+- **Method**: `GET`
+- **Path**: `/Subscriber/GetCountryFuelTypes`
+- **Query params**: `countryId` (required, int)
+- **Purpose**: Returns fuel type IDs and names.
+- **Recommended load**: Call once per day and cache locally.
+
+### 4) GetFullSiteDetails
+
+- **Method**: `GET`
+- **Path**: `/Subscriber/GetFullSiteDetails`
+- **Query params**:
+  - `countryId` (required, int; `21` = Australia)
+  - `geoRegionLevel` (required, int)
+  - `geoRegionId` (required, int)
+- **Purpose**: Returns site details for the requested region.
+- **Subscription note**: Returns only data the Data Consumer is subscribed to.
+- **Recommended load**: Call once per day and cache locally.
+
+### 5) GetSitesPrices
+
+- **Method**: `GET`
+- **Path**: `/Price/GetSitesPrices`
+- **Query params**:
+  - `countryId` (required, int; `21` = Australia)
+  - `geoRegionLevel` (required, int)
+  - `geoRegionId` (required, int)
+- **Purpose**: Returns fuel prices for sites in the requested region.
+- **Subscription note**: Returns only data the Data Consumer is subscribed to.
+- **Rate guidance**: Do not call more than once per minute.
+
+## Postman cross-check notes
+
+- The Postman collection item is named `GetSitePrices`, but its URL path is `/Price/GetSitesPrices`.
+- For implementation and tests, treat the URL path as authoritative.
+- Postman responses are not populated (`response: []`), so response-shape examples should be validated in live API testing.
+
+## Suggested Polling Pattern
+
+- Once daily:
+  - `GetBrands`
+  - `GetCountryGeographicRegions`
+  - `GetFuelTypes`
+  - `GetFullSiteDetails`
+- Frequent price sync:
+  - `GetSitesPrices` at most once per minute
+
+## Support
+
+- `support@fuelpricesqld.com.au`
+- `(07) 3858 0027`

--- a/docs/integration-operations.md
+++ b/docs/integration-operations.md
@@ -1,0 +1,100 @@
+# QLD Fuel Integration Operations Guide
+
+This guide keeps operational and troubleshooting details out of the primary
+repository `README.md`.
+
+## Home Assistant action
+
+This integration registers one Home Assistant service action:
+
+- `qld_fuel.refresh_prices`: trigger an immediate refresh for all loaded QLD
+  Fuel entries.
+
+Example service call in YAML:
+
+```yaml
+service: qld_fuel.refresh_prices
+data: {}
+```
+
+## Troubleshooting
+
+- **Invalid token during setup**: confirm your Data Consumer Token is current
+  and has no extra spaces.
+- **Cannot connect**: check Home Assistant internet connectivity and try again
+  later.
+- **No nearby stations**: increase radius or verify the selected location
+  entity/zone has valid coordinates.
+- **Stale values**: run the `qld_fuel.refresh_prices` action to force an
+  on-demand refresh.
+
+## Known limitations
+
+- Fuel prices are sourced from the published Queensland Fuel Prices API and
+  reflect that upstream data.
+- Global API payloads are cached briefly and shared across configured entries to
+  avoid excessive calls.
+- A single location (zone or location entity) can only be configured once per
+  integration instance.
+
+## Removal instructions
+
+1. Go to **Settings -> Devices & Services**.
+2. Open **Queensland Fuel Prices**.
+3. Select the entry you want to remove.
+4. Use **Delete** (three-dot menu) and confirm.
+5. Optionally remove dashboards/automations that referenced the integration
+   entities.
+
+## Developer resources
+
+- Developer portal: [Fuel Prices QLD Developers](https://www.fuelpricesqld.com.au/#developers)
+- Official Postman collection: [postmanv1.json](https://www.fuelpricesqld.com.au/documents/postmanv1.json)
+- Contributor API reference: [fuel-prices-qld-api-reference.md](./fuel-prices-qld-api-reference.md)
+- Published API PDF: [FuelPricesQLDDirectAPI(OUT)v1.6.pdf](https://www.fuelpricesqld.com.au/documents/FuelPricesQLDDirectAPI(OUT)v1.6.pdf)
+
+## Developer testing
+
+Use the repository helper script to run integration tests locally on Windows.
+
+First run (create venv, install test dependencies, then run tests):
+
+```powershell
+.\scripts\run-tests.ps1 -Install
+```
+
+Subsequent runs:
+
+```powershell
+.\scripts\run-tests.ps1
+```
+
+Manual equivalent commands:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -U pip
+.\.venv\Scripts\python.exe -m pip install -r requirements-dev.txt
+.\.venv\Scripts\python.exe -m pytest -q tests\components\qld_fuel
+```
+
+To generate explicit local coverage evidence:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests\components\qld_fuel --cov=custom_components\qld_fuel --cov-report=term-missing --cov-report=xml:coverage.xml
+```
+
+## Coverage evidence in CI
+
+The `Test Coverage` GitHub Actions workflow runs integration tests with
+`pytest-cov` and publishes:
+
+- `coverage.xml` for machine-readable coverage metrics.
+- `coverage-summary.txt` for human-readable terminal coverage output.
+
+Download these artifacts from each workflow run for measurable evidence of test
+coverage over time.
+
+If dependency installation fails on Windows (for example while building
+`greenlet`), verify Python version and architecture, then update build tools or
+use a Python version with prebuilt wheels available for the dependency set.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,9 @@
+[mypy]
+python_version = 3.12
+strict = true
+follow_imports = skip
+pretty = true
+show_error_codes = true
+
+[mypy-homeassistant.*]
+ignore_missing_imports = true

--- a/pyscript/best_fuel_near_me.py
+++ b/pyscript/best_fuel_near_me.py
@@ -1,0 +1,202 @@
+from math import radians, sin, cos, sqrt, atan2
+from datetime import datetime
+
+TRACKER_ENTITY = "person.kevyn_watkins"
+DEFAULT_RADIUS_KM = 10.0
+
+FUEL_TARGETS = {
+    "e10": {"fuel_id": "12", "label": "E10"},
+    "u91": {"fuel_id": "2", "label": "Unleaded 91"},
+    "u95": {"fuel_id": "5", "label": "Unleaded 95"},
+    "u98": {"fuel_id": "8", "label": "Unleaded 98"},
+    "diesel": {"fuel_id": "3", "label": "Diesel"},
+    "premium_diesel": {"fuel_id": "14", "label": "Premium Diesel"},
+    "lpg": {"fuel_id": "4", "label": "LPG"},
+    "e85": {"fuel_id": "19", "label": "E85"},
+}
+
+ENABLED_FUELS = ["e10", "u98"]
+
+SENSOR_PREFIX = "best"
+SENSOR_SUFFIX = "near_kevyn"
+
+
+def haversine_km(lat1, lon1, lat2, lon2):
+    r = 6371.0
+    dlat = radians(lat2 - lat1)
+    dlon = radians(lon2 - lon1)
+    a = sin(dlat / 2) ** 2 + cos(radians(lat1)) * cos(radians(lat2)) * sin(dlon / 2) ** 2
+    c = 2 * atan2(sqrt(a), sqrt(1 - a))
+    return r * c
+
+
+def safe_float(value):
+    try:
+        if value in [None, "", "unknown", "unavailable"]:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def get_tracker_coords():
+    attrs = state.getattr(TRACKER_ENTITY)
+    if not attrs:
+        return None, None
+
+    lat = safe_float(attrs.get("latitude"))
+    lon = safe_float(attrs.get("longitude"))
+
+    if lat is None or lon is None:
+        return None, None
+
+    return lat, lon
+
+def is_fuel_station_entity(entity_id):
+    if not entity_id.startswith("sensor."):
+        return False
+
+    attrs = state.getattr(entity_id)
+    if not attrs:
+        return False
+
+    if "fuel_id" not in attrs:
+        return False
+    if "latitude" not in attrs:
+        return False
+    if "longitude" not in attrs:
+        return False
+    if "address" not in attrs:
+        return False
+
+    return True
+
+def get_station_candidates(target_fuel_id, user_lat, user_lon, radius_km):
+    candidates = []
+
+    for entity_id in state.names(domain="sensor"):
+        if not is_fuel_station_entity(entity_id):
+            continue
+
+        attrs = state.getattr(entity_id)
+        if str(attrs.get("fuel_id")) != str(target_fuel_id):
+            continue
+
+        station_lat = safe_float(attrs.get("latitude"))
+        station_lon = safe_float(attrs.get("longitude"))
+        price = safe_float(state.get(entity_id))
+
+        if station_lat is None or station_lon is None or price is None:
+            continue
+
+        distance_km = haversine_km(user_lat, user_lon, station_lat, station_lon)
+        if distance_km > radius_km:
+            continue
+
+        candidates.append({
+            "entity_id": entity_id,
+            "price": price,
+            "distance_km": round(distance_km, 2),
+            "station_lat": station_lat,
+            "station_lon": station_lon,
+            "attrs": attrs,
+        })
+
+    candidates.sort(key=lambda x: (x["price"], x["distance_km"]))
+    return candidates
+
+
+def publish_result(sensor_entity_id, fuel_id, fuel_label, result, radius_km):
+    now_iso = datetime.now().isoformat()
+
+    if result is None:
+        state.set(
+            sensor_entity_id,
+            value="unknown",
+            new_attributes={
+                "friendly_name": f"Best {fuel_label} Near Kevyn",
+                "fuel_id": fuel_id,
+                "fuel_label": fuel_label,
+                "search_radius_km": radius_km,
+                "source_tracker": TRACKER_ENTITY,
+                "reason": "no_stations_in_range",
+                "last_resolved": now_iso,
+                "icon": "mdi:gas-station",
+            },
+        )
+        return
+
+    attrs = result["attrs"]
+    station_name = attrs.get("friendly_name", result["entity_id"])
+
+    state.set(
+        sensor_entity_id,
+        value=result["price"],
+        new_attributes={
+            "friendly_name": f"Best {fuel_label} Near Kevyn",
+            "station_name": station_name,
+            "station_entity_id": result["entity_id"],
+            "address": attrs.get("address"),
+            "fuel_id": fuel_id,
+            "fuel_label": fuel_label,
+            "latitude": result["station_lat"],
+            "longitude": result["station_lon"],
+            "distance_km": result["distance_km"],
+            "search_radius_km": radius_km,
+            "source_tracker": TRACKER_ENTITY,
+            "difference_to_qld_cheapest": attrs.get("difference_to_qld_cheapest"),
+            "7_day_low": attrs.get("7_day_low"),
+            "7_day_average": attrs.get("7_day_average"),
+            "14_day_low": attrs.get("14_day_low"),
+            "14_day_average": attrs.get("14_day_average"),
+            "last_resolved": now_iso,
+            "unit_of_measurement": attrs.get("unit_of_measurement"),
+            "icon": "mdi:gas-station",
+        },
+    )
+
+
+def publish_tracker_unavailable(sensor_entity_id, fuel_id, fuel_label, radius_km):
+    now_iso = datetime.now().isoformat()
+    state.set(
+        sensor_entity_id,
+        value="unknown",
+        new_attributes={
+            "friendly_name": f"Best {fuel_label} Near Kevyn",
+            "fuel_id": fuel_id,
+            "fuel_label": fuel_label,
+            "search_radius_km": radius_km,
+            "source_tracker": TRACKER_ENTITY,
+            "reason": "tracker_unavailable",
+            "last_resolved": now_iso,
+            "icon": "mdi:gas-station",
+        },
+    )
+
+
+def recalc_all(radius_km=DEFAULT_RADIUS_KM):
+    user_lat, user_lon = get_tracker_coords()
+
+    for fuel_key in ENABLED_FUELS:
+        fuel_id = FUEL_TARGETS[fuel_key]["fuel_id"]
+        fuel_label = FUEL_TARGETS[fuel_key]["label"]
+        sensor_entity_id = f"sensor.{SENSOR_PREFIX}_{fuel_key}_{SENSOR_SUFFIX}"
+
+        if user_lat is None or user_lon is None:
+            publish_tracker_unavailable(sensor_entity_id, fuel_id, fuel_label, radius_km)
+            continue
+
+        candidates = get_station_candidates(fuel_id, user_lat, user_lon, radius_km)
+        best = candidates[0] if candidates else None
+        publish_result(sensor_entity_id, fuel_id, fuel_label, best, radius_km)
+
+
+@time_trigger("startup")
+def fuel_best_near_me_startup():
+    recalc_all()
+
+
+@state_trigger(TRACKER_ENTITY)
+def fuel_best_near_me_tracker_update(value=None, old_value=None):
+    recalc_all()
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+addopts =
+    --cov=custom_components/qld_fuel
+    --cov-report=term-missing:skip-covered
+    --cov-fail-under=95

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+pytest
+pytest-cov
+pytest-homeassistant-custom-component
+greenlet<3.1
+mypy

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -1,0 +1,90 @@
+param(
+    [switch]$Install,
+    [switch]$InstallPython,
+    [string]$PythonVersion = "3.12"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-PythonCommand {
+    param([string]$Version)
+
+    if (Get-Command py -ErrorAction SilentlyContinue) {
+        & py "-$Version" -c "import sys; print(sys.version)" | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            return @("py", "-$Version")
+        }
+    }
+
+    return $null
+}
+
+function Invoke-CheckedCommand {
+    param(
+        [string]$Exe,
+        [string[]]$CommandArgs
+    )
+
+    & $Exe @CommandArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed ($LASTEXITCODE): $Exe $($CommandArgs -join ' ')"
+    }
+}
+
+function Install-PythonVersion {
+    param([string]$Version)
+
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        throw "Python $Version is required. Install winget or install Python manually from https://www.python.org/downloads/windows/"
+    }
+
+    Invoke-CheckedCommand -Exe "winget" -CommandArgs @("install", "--id", "Python.Python.$Version", "-e")
+}
+
+$pythonCmd = Get-PythonCommand -Version $PythonVersion
+if (-not $pythonCmd) {
+    if ($InstallPython) {
+        Install-PythonVersion -Version $PythonVersion
+        $pythonCmd = Get-PythonCommand -Version $PythonVersion
+    }
+}
+
+if (-not $pythonCmd) {
+    throw "Python $PythonVersion is required. Install it with: winget install --id Python.Python.$PythonVersion -e"
+}
+
+$pythonExe = $pythonCmd[0]
+$pythonArgs = @()
+if ($pythonCmd.Length -gt 1) {
+    $pythonArgs = $pythonCmd[1..($pythonCmd.Length - 1)]
+}
+$venvPython = ".\.venv\Scripts\python.exe"
+
+if (-not (Test-Path $venvPython)) {
+    Invoke-CheckedCommand -Exe $pythonExe -CommandArgs ($pythonArgs + @("-m", "venv", ".venv"))
+}
+
+$venvVersion = & $venvPython -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to detect Python version inside .venv."
+}
+
+if ($venvVersion -ne $PythonVersion) {
+    throw ".venv uses Python $venvVersion, expected $PythonVersion. Delete .venv and rerun after installing Python $PythonVersion."
+}
+
+if ($Install) {
+    Invoke-CheckedCommand -Exe $venvPython -CommandArgs @("-m", "pip", "install", "-U", "pip", "setuptools", "wheel")
+    Invoke-CheckedCommand -Exe $venvPython -CommandArgs @("-m", "pip", "install", "-r", "requirements-dev.txt")
+}
+
+& $venvPython -c "import pytest"
+if ($LASTEXITCODE -ne 0) {
+    throw "pytest is not installed in .venv. Run .\scripts\run-tests.ps1 -Install"
+}
+
+Invoke-CheckedCommand -Exe $venvPython -CommandArgs @("-m", "pytest", "-q", "tests\components\qld_fuel")
+Invoke-CheckedCommand -Exe $venvPython -CommandArgs @(
+    "-m", "mypy", "--config-file", "mypy.ini",
+    "custom_components\qld_fuel"
+)

--- a/tests/components/qld_fuel/__init__.py
+++ b/tests/components/qld_fuel/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the qld_fuel integration."""

--- a/tests/components/qld_fuel/conftest.py
+++ b/tests/components/qld_fuel/conftest.py
@@ -1,0 +1,20 @@
+"""Test fixtures for qld_fuel component tests."""
+
+import asyncio
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def event_loop_policy(socket_enabled):
+    """Use a Windows-safe loop policy without overriding event_loop."""
+    if sys.platform == "win32":
+        return asyncio.WindowsSelectorEventLoopPolicy()
+    return asyncio.DefaultEventLoopPolicy()
+
+
+@pytest.fixture
+def wait_for_stop_scripts_after_shutdown():
+    """Avoid plugin patching into Home Assistant script helpers in stubbed tests."""
+    return True

--- a/tests/components/qld_fuel/test_config_flow.py
+++ b/tests/components/qld_fuel/test_config_flow.py
@@ -1,0 +1,666 @@
+"""Config flow tests for qld_fuel."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.no_fail_on_log_exception
+
+
+_STUBBED_MODULE_PREFIXES = (
+    "homeassistant",
+    "custom_components.qld_fuel",
+    "voluptuous",
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_stubbed_modules():
+    """Keep module stubs isolated to each test case."""
+    original = {
+        name: module
+        for name, module in sys.modules.items()
+        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in _STUBBED_MODULE_PREFIXES)
+    }
+    yield
+    for name in list(sys.modules):
+        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in _STUBBED_MODULE_PREFIXES):
+            sys.modules.pop(name, None)
+    sys.modules.update(original)
+
+
+def _install_stubs() -> None:
+    """Install minimal stubs needed to import config_flow."""
+    for key in list(sys.modules):
+        if key == "homeassistant" or key.startswith("homeassistant."):
+            sys.modules.pop(key)
+
+    ha = ModuleType("homeassistant")
+    config_entries = ModuleType("homeassistant.config_entries")
+    core = ModuleType("homeassistant.core")
+    helpers = ModuleType("homeassistant.helpers")
+    selector = ModuleType("homeassistant.helpers.selector")
+    const = ModuleType("homeassistant.const")
+    voluptuous = ModuleType("voluptuous")
+
+    class AbortFlow(Exception):
+        """Abort flow stub."""
+
+    class _BaseFlow:
+        _configured_ids: set[str] = set()
+
+        def __init__(self):
+            self.hass = None
+            self.context = {}
+            self._unique_id = None
+            self._entries = []
+
+        def _async_current_entries(self):
+            return self._entries
+
+        async def async_set_unique_id(self, unique_id):
+            self._unique_id = unique_id
+
+        def _abort_if_unique_id_configured(self):
+            if self._unique_id in self._configured_ids:
+                raise AbortFlow("already_configured")
+            self._configured_ids.add(self._unique_id)
+
+        def async_create_entry(self, *, title, data):
+            return {"type": "create_entry", "title": title, "data": data}
+
+        def async_show_form(self, *, step_id, data_schema=None, errors=None):
+            return {"type": "form", "step_id": step_id, "errors": errors or {}}
+
+        def async_abort(self, *, reason):
+            return {"type": "abort", "reason": reason}
+
+        def async_update_reload_and_abort(self, entry, *, title, data):
+            entry.data = data
+            entry.title = title
+            return {"type": "abort", "reason": "reconfigure_successful"}
+
+        def _get_reauth_entry(self):
+            return SimpleNamespace(entry_id="entry-1")
+
+    class ConfigFlow(_BaseFlow):
+        def __init_subclass__(cls, **kwargs):
+            return None
+
+    class OptionsFlow(_BaseFlow):
+        pass
+
+    def callback(func):
+        return func
+
+    class EntitySelectorConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class EntitySelector:
+        def __init__(self, cfg):
+            self.cfg = cfg
+
+    class NumberSelectorConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class NumberSelector:
+        def __init__(self, cfg):
+            self.cfg = cfg
+
+    class SelectSelectorConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class SelectSelector:
+        def __init__(self, cfg):
+            self.cfg = cfg
+
+    def Required(key, default=None):
+        return key
+
+    def Optional(key, default=None):
+        return key
+
+    class Schema:
+        def __init__(self, value):
+            self.value = value
+
+    config_entries.ConfigFlow = ConfigFlow
+    config_entries.ConfigEntry = object
+    config_entries.ConfigFlowResult = dict
+    config_entries.OptionsFlow = OptionsFlow
+    config_entries.AbortFlow = AbortFlow
+    core.callback = callback
+    selector.EntitySelectorConfig = EntitySelectorConfig
+    selector.EntitySelector = EntitySelector
+    selector.NumberSelectorConfig = NumberSelectorConfig
+    selector.NumberSelector = NumberSelector
+    selector.SelectSelectorConfig = SelectSelectorConfig
+    selector.SelectSelector = SelectSelector
+    const.CONF_LATITUDE = "latitude"
+    const.CONF_LONGITUDE = "longitude"
+    voluptuous.Required = Required
+    voluptuous.Optional = Optional
+    voluptuous.Schema = Schema
+
+    sys.modules["homeassistant"] = ha
+    sys.modules["homeassistant.config_entries"] = config_entries
+    sys.modules["homeassistant.core"] = core
+    sys.modules["homeassistant.helpers"] = helpers
+    sys.modules["homeassistant.helpers.selector"] = selector
+    sys.modules["homeassistant.const"] = const
+    sys.modules["voluptuous"] = voluptuous
+
+
+def _load_config_flow_module():
+    """Load config_flow.py directly with stubs."""
+    _install_stubs()
+
+    const_module = ModuleType("custom_components.qld_fuel.const")
+    const_module.DOMAIN = "qld_fuel"
+    const_module.TOKEN = "subscriber_token"
+    const_module.RADIUS = "radius"
+    const_module.FUEL_TYPES = "fuel_types"
+    const_module.FUEL_TYPES_OPTIONS = [{"value": "12", "label": "E10"}]
+    const_module.SCAN_INTERVAL = "scan_interval"
+    const_module.LOCATION_ENTITY = "location_entity"
+    const_module.ZONE = "zone"
+    sys.modules["custom_components.qld_fuel.const"] = const_module
+
+    coordinator_module = ModuleType("custom_components.qld_fuel.coordinator")
+
+    class QldFuelAuthError(Exception):
+        pass
+
+    class QldFuelConnectionError(Exception):
+        pass
+
+    async def async_validate_token(_hass, token):
+        if token == "bad":
+            raise QldFuelAuthError("bad token")
+        if token == "offline":
+            raise QldFuelConnectionError("offline")
+        return None
+
+    coordinator_module.QldFuelAuthError = QldFuelAuthError
+    coordinator_module.QldFuelConnectionError = QldFuelConnectionError
+    coordinator_module.async_validate_token = async_validate_token
+    sys.modules["custom_components.qld_fuel.coordinator"] = coordinator_module
+
+    package = ModuleType("custom_components.qld_fuel")
+    package.__path__ = []
+    sys.modules["custom_components.qld_fuel"] = package
+
+    path = Path(__file__).resolve().parents[3] / "custom_components" / "qld_fuel" / "config_flow.py"
+    spec = importlib.util.spec_from_file_location(
+        "custom_components.qld_fuel.config_flow",
+        str(path),
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["custom_components.qld_fuel.config_flow"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _States:
+    def __init__(self, values):
+        self._values = values
+
+    def get(self, entity_id):
+        return self._values.get(entity_id)
+
+
+def _state(name: str, lat: float | None, lon: float | None):
+    return SimpleNamespace(name=name, attributes={"latitude": lat, "longitude": lon})
+
+
+def test_user_step_creates_entry_when_token_valid():
+    """User step creates entry when location and token validate."""
+    module = _load_config_flow_module()
+    module.QldFuelConfigFlow._configured_ids.clear()
+    flow = module.QldFuelConfigFlow()
+    flow.hass = SimpleNamespace(states=_States({"zone.home": _state("Home", -27.5, 153.0)}))
+    flow._entries = []
+
+    result = asyncio.run(
+        flow.async_step_user(
+            {
+                "subscriber_token": "good",
+                "zone": "zone.home",
+                "radius": 5,
+                "fuel_types": ["12"],
+                "scan_interval": 6,
+            }
+        )
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "Fuel near Home"
+    assert result["data"]["is_master"] is True
+
+
+def test_user_step_shows_invalid_auth_error():
+    """Invalid token returns invalid_auth on the form."""
+    module = _load_config_flow_module()
+    module.QldFuelConfigFlow._configured_ids.clear()
+    flow = module.QldFuelConfigFlow()
+    flow.hass = SimpleNamespace(states=_States({"zone.home": _state("Home", -27.5, 153.0)}))
+    flow._entries = []
+
+    result = asyncio.run(
+        flow.async_step_user(
+            {
+                "subscriber_token": "bad",
+                "zone": "zone.home",
+                "radius": 5,
+                "fuel_types": ["12"],
+                "scan_interval": 6,
+            }
+        )
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"]["base"] == "invalid_auth"
+
+
+def test_user_step_reports_zone_not_found():
+    """Missing zone entity reports zone_not_found."""
+    module = _load_config_flow_module()
+    module.QldFuelConfigFlow._configured_ids.clear()
+    flow = module.QldFuelConfigFlow()
+    flow.hass = SimpleNamespace(states=_States({}))
+    flow._entries = []
+
+    result = asyncio.run(
+        flow.async_step_user(
+            {
+                "subscriber_token": "good",
+                "zone": "zone.missing",
+                "radius": 5,
+                "fuel_types": ["12"],
+                "scan_interval": 6,
+            }
+        )
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"]["zone"] == "zone_not_found"
+
+
+def test_user_step_aborts_when_unique_location_already_configured():
+    """Second flow with same location unique id aborts as already configured."""
+    module = _load_config_flow_module()
+    module.QldFuelConfigFlow._configured_ids.clear()
+    flow1 = module.QldFuelConfigFlow()
+    flow1.hass = SimpleNamespace(states=_States({"zone.home": _state("Home", -27.5, 153.0)}))
+    flow1._entries = []
+    asyncio.run(
+        flow1.async_step_user(
+            {
+                "subscriber_token": "good",
+                "zone": "zone.home",
+                "radius": 5,
+                "fuel_types": ["12"],
+                "scan_interval": 6,
+            }
+        )
+    )
+
+    flow2 = module.QldFuelConfigFlow()
+    flow2.hass = SimpleNamespace(states=_States({"zone.home": _state("Home", -27.5, 153.0)}))
+    flow2._entries = []
+
+    abort_cls = sys.modules["homeassistant.config_entries"].AbortFlow
+    try:
+        asyncio.run(
+            flow2.async_step_user(
+                {
+                    "subscriber_token": "good",
+                    "zone": "zone.home",
+                    "radius": 5,
+                    "fuel_types": ["12"],
+                    "scan_interval": 6,
+                }
+            )
+        )
+    except abort_cls as err:
+        assert "already_configured" in str(err)
+    else:
+        raise AssertionError("Expected flow to abort for duplicate unique ID")
+
+
+def test_coords_from_state_handles_missing_and_invalid_values():
+    module = _load_config_flow_module()
+    assert module.QldFuelConfigFlow._coords_from_state(None) == (None, None)
+    assert module.QldFuelConfigFlow._coords_from_state(SimpleNamespace(attributes={})) == (
+        None,
+        None,
+    )
+    bad_state = SimpleNamespace(attributes={"latitude": "x", "longitude": 153.0})
+    assert module.QldFuelConfigFlow._coords_from_state(bad_state) == (None, None)
+    good_state = SimpleNamespace(attributes={"latitude": "-27.5", "longitude": "153.0"})
+    assert module.QldFuelConfigFlow._coords_from_state(good_state) == (-27.5, 153.0)
+
+
+def test_build_location_unique_id_prefers_location_then_zone_then_coords():
+    module = _load_config_flow_module()
+    flow = module.QldFuelConfigFlow()
+    assert flow._build_location_unique_id({"location_entity": "person.test"}, -27.5, 153.0) == (
+        "location:person.test"
+    )
+    assert flow._build_location_unique_id({"zone": "zone.home"}, -27.5, 153.0) == "zone:zone.home"
+    assert flow._build_location_unique_id({}, -27.5, 153.0) == "coords:-27.500000,153.000000"
+
+
+def test_resolve_location_reports_location_missing_then_zone_missing():
+    module = _load_config_flow_module()
+    flow = module.QldFuelConfigFlow()
+    flow.hass = SimpleNamespace(states=_States({}))
+    errors = {}
+    lat, lon, name = flow._resolve_location(
+        {"location_entity": "person.missing", "zone": "zone.missing"}, errors
+    )
+    assert (lat, lon, name) == (None, None, None)
+    assert errors["location_entity"] == "location_entity_not_found"
+    assert errors["zone"] == "zone_not_found"
+
+
+def test_user_step_uses_master_token_when_master_exists():
+    module = _load_config_flow_module()
+    module.QldFuelConfigFlow._configured_ids.clear()
+    master_entry = SimpleNamespace(data={"is_master": True, "subscriber_token": "shared"})
+    flow = module.QldFuelConfigFlow()
+    flow.hass = SimpleNamespace(states=_States({"zone.home": _state("Home", -27.5, 153.0)}))
+    flow._entries = [master_entry]
+
+    result = asyncio.run(
+        flow.async_step_user(
+            {
+                "zone": "zone.home",
+                "radius": 5,
+                "fuel_types": ["12"],
+                "scan_interval": 6,
+            }
+        )
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"]["is_master"] is False
+    assert result["data"]["subscriber_token"] == "shared"
+
+
+def test_user_step_shows_cannot_connect_error():
+    module = _load_config_flow_module()
+    module.QldFuelConfigFlow._configured_ids.clear()
+    flow = module.QldFuelConfigFlow()
+    flow.hass = SimpleNamespace(states=_States({"zone.home": _state("Home", -27.5, 153.0)}))
+    flow._entries = []
+
+    result = asyncio.run(
+        flow.async_step_user(
+            {
+                "subscriber_token": "offline",
+                "zone": "zone.home",
+                "radius": 5,
+                "fuel_types": ["12"],
+                "scan_interval": 6,
+            }
+        )
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "cannot_connect"
+
+
+def test_reauth_confirm_invalid_auth_and_cannot_connect():
+    module = _load_config_flow_module()
+    flow = module.QldFuelConfigFlow()
+    flow.hass = SimpleNamespace(
+        config_entries=SimpleNamespace(async_get_entry=lambda _entry_id: None),
+    )
+    flow.context = {"entry_id": "entry-1"}
+
+    bad = asyncio.run(flow.async_step_reauth_confirm({"subscriber_token": "bad"}))
+    assert bad["type"] == "form"
+    assert bad["errors"]["base"] == "invalid_auth"
+
+    offline = asyncio.run(flow.async_step_reauth_confirm({"subscriber_token": "offline"}))
+    assert offline["type"] == "form"
+    assert offline["errors"]["base"] == "cannot_connect"
+
+
+def test_reauth_confirm_updates_entry_when_present():
+    module = _load_config_flow_module()
+    entry = SimpleNamespace(data={"subscriber_token": "old"})
+    calls = []
+
+    def _update_entry(updated_entry, data):
+        calls.append((updated_entry, data))
+
+    flow = module.QldFuelConfigFlow()
+    flow.hass = SimpleNamespace(
+        config_entries=SimpleNamespace(
+            async_get_entry=lambda _entry_id: entry,
+            async_update_entry=_update_entry,
+        ),
+    )
+    flow.context = {"entry_id": "entry-1"}
+
+    result = asyncio.run(flow.async_step_reauth_confirm({"subscriber_token": "good"}))
+    assert result["type"] == "abort"
+    assert result["reason"] == "reauth_successful"
+    assert calls
+    assert calls[0][1]["subscriber_token"] == "good"
+
+
+def test_reconfigure_updates_data_and_preserves_non_master_token():
+    module = _load_config_flow_module()
+    entry = SimpleNamespace(
+        data={"is_master": False, "subscriber_token": "child-token"},
+        options={},
+        title="Old title",
+    )
+    master = SimpleNamespace(data={"is_master": True, "subscriber_token": "master-token"})
+    flow = module.QldFuelConfigFlow()
+    flow.context = {"entry_id": "entry-2"}
+    flow.hass = SimpleNamespace(
+        states=_States({"zone.home": _state("Home", -27.6, 153.1)}),
+        config_entries=SimpleNamespace(async_get_entry=lambda _entry_id: entry),
+    )
+    flow._entries = [master, entry]
+
+    result = asyncio.run(
+        flow.async_step_reconfigure(
+            {
+                "zone": "zone.home",
+                "radius": 3,
+                "fuel_types": ["12"],
+                "scan_interval": 2,
+            }
+        )
+    )
+
+    assert result["type"] == "abort"
+    assert entry.data["subscriber_token"] == "master-token"
+    assert entry.data["is_master"] is False
+    assert entry.data["latitude"] == -27.6
+    assert entry.title == "Fuel near Home"
+
+
+def test_options_flow_init_error_and_success_paths():
+    module = _load_config_flow_module()
+    config_entry = SimpleNamespace(
+        data={"zone": "zone.home", "radius": 5, "fuel_types": ["12"], "scan_interval": 6},
+        options={},
+    )
+    flow = module.QldFuelOptionsFlowHandler(config_entry)
+    flow.hass = SimpleNamespace(states=_States({}))
+
+    missing = asyncio.run(
+        flow.async_step_init(
+            {
+                "zone": "zone.missing",
+                "radius": 5,
+                "fuel_types": ["12"],
+                "scan_interval": 6,
+            }
+        )
+    )
+    assert missing["type"] == "form"
+    assert missing["errors"]["zone"] == "zone_not_found"
+
+    flow.hass = SimpleNamespace(states=_States({"zone.home": _state("Home", -27.5, 153.0)}))
+    ok = asyncio.run(
+        flow.async_step_init(
+            {
+                "zone": "zone.home",
+                "radius": 5,
+                "fuel_types": ["12"],
+                "scan_interval": 6,
+            }
+        )
+    )
+    assert ok["type"] == "create_entry"
+    assert ok["data"]["latitude"] == -27.5
+
+
+def test_async_get_options_flow_and_reauth_step():
+    module = _load_config_flow_module()
+    entry = SimpleNamespace()
+    options_flow = module.QldFuelConfigFlow.async_get_options_flow(entry)
+    assert isinstance(options_flow, module.QldFuelOptionsFlowHandler)
+
+    flow = module.QldFuelConfigFlow()
+    called = []
+
+    async def _reauth_confirm():
+        called.append(True)
+        return {"type": "form", "step_id": "reauth_confirm"}
+
+    flow.async_step_reauth_confirm = _reauth_confirm
+    result = asyncio.run(flow.async_step_reauth({"subscriber_token": "x"}))
+    assert result["step_id"] == "reauth_confirm"
+    assert flow.context["entry_id"] == "entry-1"
+    assert called
+
+
+def test_resolve_location_handles_missing_location_coordinates():
+    module = _load_config_flow_module()
+    flow = module.QldFuelConfigFlow()
+    flow.hass = SimpleNamespace(
+        states=_States(
+            {
+                "person.test": _state("Tracker", None, 153.0),
+                "zone.home": _state("Home", -27.5, 153.0),
+            }
+        )
+    )
+    errors = {}
+    lat, lon, name = flow._resolve_location(
+        {"location_entity": "person.test", "zone": "zone.home"},
+        errors,
+    )
+    assert (lat, lon, name) == (-27.5, 153.0, "Home")
+    assert errors["location_entity"] == "location_entity_missing_coordinates"
+
+
+def test_resolve_location_rejects_zone_without_coordinates():
+    module = _load_config_flow_module()
+    flow = module.QldFuelConfigFlow()
+    flow.hass = SimpleNamespace(states=_States({"zone.home": _state("Home", None, None)}))
+    errors = {}
+    lat, lon, name = flow._resolve_location({"zone": "zone.home"}, errors)
+    assert (lat, lon, name) == (None, None, None)
+    assert errors["zone"] == "zone_not_found"
+
+
+def test_reconfigure_form_for_master_with_existing_location_entity():
+    module = _load_config_flow_module()
+    entry = SimpleNamespace(
+        data={"is_master": True, "subscriber_token": "token", "location_entity": "person.a"},
+        options={"location_entity": "person.a", "zone": "zone.home"},
+        title="Fuel near Home",
+    )
+    flow = module.QldFuelConfigFlow()
+    flow.context = {"entry_id": "entry-1"}
+    flow.hass = SimpleNamespace(config_entries=SimpleNamespace(async_get_entry=lambda _entry_id: entry))
+    flow._entries = [entry]
+    result = asyncio.run(flow.async_step_reconfigure(None))
+    assert result["type"] == "form"
+    assert result["step_id"] == "reconfigure"
+
+
+def test_options_flow_coords_and_resolve_location_branches():
+    module = _load_config_flow_module()
+    entry = SimpleNamespace(data={"zone": "zone.home"}, options={})
+    flow = module.QldFuelOptionsFlowHandler(entry)
+    assert flow._coords_from_state(None) == (None, None)
+    assert flow._coords_from_state(SimpleNamespace(attributes={})) == (None, None)
+    assert flow._coords_from_state(SimpleNamespace(attributes={"latitude": "x", "longitude": 1})) == (
+        None,
+        None,
+    )
+    flow.hass = SimpleNamespace(
+        states=_States(
+            {
+                "person.bad": _state("Bad", None, None),
+                "zone.bad": _state("BadZone", None, None),
+            }
+        )
+    )
+    errors = {}
+    assert flow._resolve_location({"location_entity": "person.bad", "zone": "zone.bad"}, errors) == (
+        None,
+        None,
+    )
+    assert errors["location_entity"] == "location_entity_missing_coordinates"
+    assert errors["zone"] == "zone_not_found"
+
+
+def test_resolve_location_returns_location_entity_coordinates_when_valid():
+    module = _load_config_flow_module()
+    flow = module.QldFuelConfigFlow()
+    flow.hass = SimpleNamespace(
+        states=_States(
+            {
+                "person.good": _state("Tracker", -27.51, 153.01),
+                "zone.home": _state("Home", -27.5, 153.0),
+            }
+        )
+    )
+    errors = {}
+    lat, lon, name = flow._resolve_location(
+        {"location_entity": "person.good", "zone": "zone.home"},
+        errors,
+    )
+    assert (lat, lon, name) == (-27.51, 153.01, "Tracker")
+    assert errors == {}
+
+
+def test_options_flow_resolve_location_success_and_location_missing():
+    module = _load_config_flow_module()
+    entry = SimpleNamespace(data={"zone": "zone.home"}, options={})
+    flow = module.QldFuelOptionsFlowHandler(entry)
+    flow.hass = SimpleNamespace(states=_States({"person.good": _state("Tracker", -27.5, 153.0)}))
+    errors = {}
+    assert flow._resolve_location({"location_entity": "person.good", "zone": "zone.missing"}, errors) == (
+        -27.5,
+        153.0,
+    )
+    errors = {}
+    assert flow._resolve_location({"location_entity": "person.missing", "zone": "zone.missing"}, errors) == (
+        None,
+        None,
+    )
+    assert errors["location_entity"] == "location_entity_not_found"

--- a/tests/components/qld_fuel/test_const_and_diagnostics_edges.py
+++ b/tests/components/qld_fuel/test_const_and_diagnostics_edges.py
@@ -1,0 +1,89 @@
+"""Extra coverage tests for const and diagnostics helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.no_fail_on_log_exception
+
+
+def test_const_module_import_and_values():
+    path = Path(__file__).resolve().parents[3] / "custom_components" / "qld_fuel" / "const.py"
+    spec = importlib.util.spec_from_file_location("custom_components.qld_fuel.const_real", str(path))
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    assert module.DOMAIN == "qld_fuel"
+    assert isinstance(module.FUEL_TYPES_OPTIONS, list)
+    assert module.PLATFORMS == ["sensor"]
+
+
+def _load_diagnostics():
+    for key in list(sys.modules):
+        if key == "homeassistant" or key.startswith("homeassistant.") or key.startswith("custom_components.qld_fuel"):
+            sys.modules.pop(key)
+
+    homeassistant = ModuleType("homeassistant")
+    homeassistant.__path__ = []
+    sys.modules["homeassistant"] = homeassistant
+
+    diagnostics_comp = ModuleType("homeassistant.components.diagnostics")
+    diagnostics_comp.async_redact_data = lambda value, _keys: value
+    sys.modules["homeassistant.components.diagnostics"] = diagnostics_comp
+
+    config_entries = ModuleType("homeassistant.config_entries")
+    config_entries.ConfigEntry = object
+    sys.modules["homeassistant.config_entries"] = config_entries
+
+    core = ModuleType("homeassistant.core")
+    core.HomeAssistant = object
+    sys.modules["homeassistant.core"] = core
+
+    const_module = ModuleType("custom_components.qld_fuel.const")
+    const_module.DOMAIN = "qld_fuel"
+    const_module.TOKEN = "subscriber_token"
+    sys.modules["custom_components.qld_fuel.const"] = const_module
+
+    coordinator_module = ModuleType("custom_components.qld_fuel.coordinator")
+
+    class QldFuelDataUpdateCoordinator:
+        def __init__(self, data):
+            self.data = data
+
+    coordinator_module.QldFuelDataUpdateCoordinator = QldFuelDataUpdateCoordinator
+    sys.modules["custom_components.qld_fuel.coordinator"] = coordinator_module
+
+    package = ModuleType("custom_components.qld_fuel")
+    package.__path__ = []
+    sys.modules["custom_components.qld_fuel"] = package
+
+    path = Path(__file__).resolve().parents[3] / "custom_components" / "qld_fuel" / "diagnostics.py"
+    spec = importlib.util.spec_from_file_location("custom_components.qld_fuel.diagnostics", str(path))
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["custom_components.qld_fuel.diagnostics"] = module
+    spec.loader.exec_module(module)
+    return module, QldFuelDataUpdateCoordinator
+
+
+def test_diagnostics_sanitize_helpers_return_none_on_empty():
+    module, coordinator_cls = _load_diagnostics()
+    assert module._sanitize_raw_payload(None) is None
+    assert module._sanitize_processed_payload(None) is None
+
+    entry = SimpleNamespace(
+        entry_id="entry-1",
+        title="Fuel",
+        data={},
+        options={},
+        runtime_data=coordinator_cls(None),
+    )
+    hass = SimpleNamespace(data={"qld_fuel": {}})
+    result = asyncio.run(module.async_get_config_entry_diagnostics(hass, entry))
+    assert result["coordinator"]["payload_snapshot"] is None

--- a/tests/components/qld_fuel/test_coordinator.py
+++ b/tests/components/qld_fuel/test_coordinator.py
@@ -1,0 +1,474 @@
+"""Coordinator tests for qld_fuel."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from datetime import datetime, timedelta
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.no_fail_on_log_exception
+
+
+def _install_homeassistant_stubs() -> None:
+    """Install minimal Home Assistant stubs for local unit tests."""
+    for key in list(sys.modules):
+        if key == "homeassistant" or key.startswith("homeassistant."):
+            sys.modules.pop(key)
+
+    ha = ModuleType("homeassistant")
+    helpers = ModuleType("homeassistant.helpers")
+    aiohttp_client = ModuleType("homeassistant.helpers.aiohttp_client")
+    event = ModuleType("homeassistant.helpers.event")
+    update_coordinator = ModuleType("homeassistant.helpers.update_coordinator")
+    issue_registry = ModuleType("homeassistant.helpers.issue_registry")
+    core = ModuleType("homeassistant.core")
+    util = ModuleType("homeassistant.util")
+    util_dt = ModuleType("homeassistant.util.dt")
+    util_location = ModuleType("homeassistant.util.location")
+    const = ModuleType("homeassistant.const")
+    ha.__path__ = []
+    helpers.__path__ = []
+
+    class UpdateFailed(Exception):
+        """Update failed."""
+
+    class DataUpdateCoordinator:
+        """Minimal DataUpdateCoordinator stub."""
+
+        def __init__(self, hass, logger, name, update_interval):
+            self.hass = hass
+            self.logger = logger
+            self.name = name
+            self.update_interval = update_interval
+            self.data = {}
+
+        def async_set_updated_data(self, data):
+            self.data = data
+
+    def callback(func):
+        return func
+
+    async def _unneeded_async_get_clientsession(hass):
+        raise AssertionError("Network path should not be used by these tests")
+
+    def _track_state_change_event(_hass, _entities, _listener):
+        return lambda: None
+
+    def _distance(lat1, lon1, lat2, lon2):
+        return ((float(lat1) - float(lat2)) ** 2 + (float(lon1) - float(lon2)) ** 2) ** 0.5 * 1000
+
+    aiohttp_client.async_get_clientsession = _unneeded_async_get_clientsession
+    event.async_track_state_change_event = _track_state_change_event
+    update_coordinator.DataUpdateCoordinator = DataUpdateCoordinator
+    update_coordinator.UpdateFailed = UpdateFailed
+    issue_registry.IssueSeverity = SimpleNamespace(ERROR="error")
+    issue_registry.async_create_issue = lambda *args, **kwargs: None
+    issue_registry.async_delete_issue = lambda *args, **kwargs: None
+    core.callback = callback
+    util_dt.utcnow = lambda: None
+    util_location.distance = _distance
+    const.CONF_LATITUDE = "latitude"
+    const.CONF_LONGITUDE = "longitude"
+
+    sys.modules["homeassistant"] = ha
+    sys.modules["homeassistant.helpers"] = helpers
+    sys.modules["homeassistant.helpers.aiohttp_client"] = aiohttp_client
+    sys.modules["homeassistant.helpers.event"] = event
+    sys.modules["homeassistant.helpers.update_coordinator"] = update_coordinator
+    sys.modules["homeassistant.helpers.issue_registry"] = issue_registry
+    sys.modules["homeassistant.core"] = core
+    sys.modules["homeassistant.util"] = util
+    sys.modules["homeassistant.util.dt"] = util_dt
+    sys.modules["homeassistant.util.location"] = util_location
+    sys.modules["homeassistant.const"] = const
+
+
+def _load_coordinator_module():
+    """Load coordinator.py directly, without importing package __init__."""
+    _install_homeassistant_stubs()
+
+    const_module = ModuleType("custom_components.qld_fuel.const")
+    const_module.DOMAIN = "qld_fuel"
+    const_module.TOKEN = "subscriber_token"
+    const_module.RADIUS = "radius"
+    const_module.SCAN_INTERVAL = "scan_interval"
+    const_module.LOCATION_ENTITY = "location_entity"
+    const_module.ZONE = "zone"
+    sys.modules["custom_components.qld_fuel.const"] = const_module
+
+    package = ModuleType("custom_components.qld_fuel")
+    package.__path__ = []  # mark as package
+    sys.modules["custom_components.qld_fuel"] = package
+
+    path = Path(__file__).resolve().parents[3] / "custom_components" / "qld_fuel" / "coordinator.py"
+    spec = importlib.util.spec_from_file_location(
+        "custom_components.qld_fuel.coordinator",
+        str(path),
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["custom_components.qld_fuel.coordinator"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _StateMachine:
+    def __init__(self, states):
+        self._states = states
+
+    def get(self, entity_id):
+        return self._states.get(entity_id)
+
+
+class _FakeHass:
+    def __init__(self, states):
+        self.states = _StateMachine(states)
+        self.config = SimpleNamespace(latitude=-27.5, longitude=153.0)
+        self.data = {"qld_fuel": {}}
+        self._created_tasks = []
+
+    def async_create_task(self, coro):
+        self._created_tasks.append(coro)
+
+
+def _state(name: str, lat: float | None, lon: float | None):
+    return SimpleNamespace(name=name, attributes={"latitude": lat, "longitude": lon})
+
+
+def test_resolve_entry_coords_prefers_location_entity():
+    """Location entity takes precedence over zone and legacy coordinates."""
+    module = _load_coordinator_module()
+
+    hass = _FakeHass(
+        {
+            "person.test": _state("Test Person", -27.11, 153.11),
+            "zone.home": _state("Home", -27.55, 153.55),
+        }
+    )
+    entry = SimpleNamespace(
+        data={
+            "location_entity": "person.test",
+            "zone": "zone.home",
+            "latitude": -28.0,
+            "longitude": 154.0,
+            "scan_interval": 6,
+        },
+        options={},
+        title="Fuel near Test",
+    )
+
+    coordinator = module.QldFuelDataUpdateCoordinator(hass, entry)
+    lat, lon, source = coordinator._resolve_entry_coords()
+
+    assert (lat, lon) == (-27.11, 153.11)
+    assert source == "person.test"
+
+
+def test_async_recompute_from_cache_updates_data():
+    """Recompute path updates coordinator from cached raw data only."""
+    module = _load_coordinator_module()
+
+    hass = _FakeHass({"zone.home": _state("Home", -27.55, 153.55)})
+    entry = SimpleNamespace(
+        data={"zone": "zone.home", "scan_interval": 6},
+        options={},
+        title="Fuel near Home",
+    )
+    coordinator = module.QldFuelDataUpdateCoordinator(hass, entry)
+
+    raw_data = {"sites": [{"S": "1"}], "prices": []}
+    hass.data["qld_fuel"]["raw_data"] = raw_data
+    coordinator._process_raw_data = lambda payload: {"processed": payload["sites"][0]["S"]}
+
+    asyncio.run(coordinator.async_recompute_from_cache())
+
+    assert coordinator.data == {"processed": "1"}
+
+
+class _FakeResponse:
+    def __init__(self, status, payload=None):
+        self.status = status
+        self._payload = payload or {}
+
+    async def json(self):
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    def get(self, _url, headers=None):
+        assert headers is not None
+        return self._responses.pop(0)
+
+
+def test_validate_token_paths():
+    module = _load_coordinator_module()
+    hass = _FakeHass({})
+
+    with pytest.raises(module.QldFuelAuthError):
+        asyncio.run(module.async_validate_token(hass, None))
+
+    module.async_get_clientsession = lambda _hass: _FakeSession([_FakeResponse(401)])
+    with pytest.raises(module.QldFuelAuthError):
+        asyncio.run(module.async_validate_token(hass, "token"))
+
+    module.async_get_clientsession = lambda _hass: _FakeSession([_FakeResponse(500)])
+    with pytest.raises(module.QldFuelConnectionError):
+        asyncio.run(module.async_validate_token(hass, "token"))
+
+    class _BrokenSession:
+        def get(self, _url, headers=None):
+            raise RuntimeError("boom")
+
+    module.async_get_clientsession = lambda _hass: _BrokenSession()
+    with pytest.raises(module.QldFuelConnectionError):
+        asyncio.run(module.async_validate_token(hass, "token"))
+
+
+def test_resolve_entry_coords_falls_back_to_zone_then_stored_coords():
+    module = _load_coordinator_module()
+    hass = _FakeHass({"zone.home": _state("Home", -27.5, 153.0)})
+    entry = SimpleNamespace(
+        data={"zone": "zone.home", "scan_interval": 6, "latitude": -28.0, "longitude": 154.0},
+        options={},
+        title="Fuel near Home",
+    )
+    coordinator = module.QldFuelDataUpdateCoordinator(hass, entry)
+    assert coordinator._resolve_entry_coords() == (-27.5, 153.0, "zone.home")
+
+    hass = _FakeHass({})
+    bad_entry = SimpleNamespace(
+        data={"scan_interval": 6, "latitude": "bad", "longitude": "bad"},
+        options={},
+        title="Fuel near Bad",
+    )
+    coordinator = module.QldFuelDataUpdateCoordinator(hass, bad_entry)
+    assert coordinator._resolve_entry_coords() == (None, None, None)
+
+
+def test_setup_location_listener_paths_and_change_detection():
+    module = _load_coordinator_module()
+    calls = []
+
+    def _track(_hass, _entities, listener):
+        calls.append(listener)
+        return lambda: calls.append("removed")
+
+    module.async_track_state_change_event = _track
+
+    hass = _FakeHass({"person.test": _state("Person", -27.5, 153.0)})
+    entry = SimpleNamespace(
+        data={"location_entity": "person.test", "scan_interval": 6},
+        options={},
+        title="Fuel",
+    )
+    coordinator = module.QldFuelDataUpdateCoordinator(hass, entry)
+
+    asyncio.run(coordinator.async_setup_location_listener())
+    assert coordinator._remove_location_listener is not None
+
+    asyncio.run(coordinator.async_setup_location_listener())
+    assert len(calls) == 1
+
+    listener = calls[0]
+    same_event = {"data": {"old_state": _state("P", -27.5, 153.0), "new_state": _state("P", -27.5, 153.0)}}
+    listener(SimpleNamespace(**same_event))
+    assert hass._created_tasks == []
+
+    changed_event = {"data": {"old_state": _state("P", -27.5, 153.0), "new_state": _state("P", -27.4, 153.0)}}
+    listener(SimpleNamespace(**changed_event))
+    assert len(hass._created_tasks) == 1
+    hass._created_tasks[0].close()
+
+
+def test_async_update_data_fetch_and_cache_paths():
+    module = _load_coordinator_module()
+    now = [datetime(2026, 1, 1, 0, 0, 0)]
+    module.dt_util.utcnow = lambda: now[0]
+    hass = _FakeHass({"zone.home": _state("Home", -27.5, 153.0)})
+    entry = SimpleNamespace(
+        entry_id="entry-1",
+        data={"scan_interval": 6, "subscriber_token": "token", "zone": "zone.home"},
+        options={},
+        title="Fuel",
+    )
+    coordinator = module.QldFuelDataUpdateCoordinator(hass, entry)
+    coordinator._process_raw_data = lambda data: {"processed": data["sites"]}
+    coordinator._fetch_from_api = lambda: asyncio.sleep(0, result={"sites": [{"S": "1"}], "prices": []})
+
+    result = asyncio.run(coordinator._async_update_data())
+    assert result["processed"] == [{"S": "1"}]
+    assert "fetch_lock" in hass.data["qld_fuel"]
+
+    now[0] = now[0] + timedelta(minutes=1)
+    result2 = asyncio.run(coordinator._async_update_data())
+    assert result2["processed"] == [{"S": "1"}]
+
+
+def test_async_update_data_error_paths_raise_update_failed():
+    module = _load_coordinator_module()
+    module.dt_util.utcnow = lambda: 1000
+    hass = _FakeHass({"zone.home": _state("Home", -27.5, 153.0)})
+    entry = SimpleNamespace(
+        entry_id="entry-1",
+        data={"scan_interval": 6, "subscriber_token": "token", "zone": "zone.home"},
+        options={},
+        title="Fuel",
+    )
+    coordinator = module.QldFuelDataUpdateCoordinator(hass, entry)
+
+    coordinator._fetch_from_api = lambda: asyncio.sleep(0, result=(_ for _ in ()).throw(module.QldFuelAuthError("bad")))
+    with pytest.raises(sys.modules["homeassistant.helpers.update_coordinator"].UpdateFailed):
+        asyncio.run(coordinator._async_update_data())
+
+    coordinator._fetch_from_api = lambda: asyncio.sleep(
+        0, result=(_ for _ in ()).throw(module.QldFuelConnectionError("down"))
+    )
+    with pytest.raises(sys.modules["homeassistant.helpers.update_coordinator"].UpdateFailed):
+        asyncio.run(coordinator._async_update_data())
+
+
+def test_fetch_from_api_status_and_payload_paths():
+    module = _load_coordinator_module()
+    hass = _FakeHass({})
+    entry = SimpleNamespace(data={"subscriber_token": "token", "scan_interval": 6}, options={}, title="Fuel")
+    coordinator = module.QldFuelDataUpdateCoordinator(hass, entry)
+
+    with pytest.raises(sys.modules["homeassistant.helpers.update_coordinator"].UpdateFailed):
+        coordinator.entry.data.pop("subscriber_token")
+        asyncio.run(coordinator._fetch_from_api())
+
+    coordinator.entry.data["subscriber_token"] = "token"
+    module.async_get_clientsession = lambda _hass: _FakeSession(
+        [
+            _FakeResponse(200, {"S": [{"S": "1"}]}),
+            _FakeResponse(200, {"SitePrices": [{"FuelId": "12"}]}),
+        ]
+    )
+    payload = asyncio.run(coordinator._fetch_from_api())
+    assert payload["sites"] == [{"S": "1"}]
+    assert payload["prices"] == [{"FuelId": "12"}]
+
+    module.async_get_clientsession = lambda _hass: _FakeSession([_FakeResponse(403)])
+    with pytest.raises(module.QldFuelAuthError):
+        asyncio.run(coordinator._fetch_from_api())
+
+    module.async_get_clientsession = lambda _hass: _FakeSession([_FakeResponse(500)])
+    with pytest.raises(module.QldFuelConnectionError):
+        asyncio.run(coordinator._fetch_from_api())
+
+
+def test_process_raw_data_and_filter_to_zone_branches():
+    module = _load_coordinator_module()
+    hass = _FakeHass({})
+    entry = SimpleNamespace(data={"scan_interval": 6, "radius": 1}, options={}, title="Fuel")
+    coordinator = module.QldFuelDataUpdateCoordinator(hass, entry)
+    coordinator._resolve_entry_coords = lambda: (-27.5, 153.0, "zone.home")
+    raw_data = {
+        "sites": [
+            {"S": "1", "N": "A", "A": "addr", "P": "4000", "Lat": -27.5, "Lng": 153.0},
+            {"S": "2", "N": "B", "A": "addr2", "P": "4001", "Lat": "bad", "Lng": 153.1},
+        ],
+        "prices": [
+            {"FuelId": "12", "SiteId": "1", "Price": 1999},
+            {"FuelId": "12", "SiteId": "1", "Price": 0},
+            {"FuelId": "5", "SiteId": "1", "Price": 1500},
+        ],
+    }
+    processed = coordinator._process_raw_data(raw_data)
+    assert "1" in processed["sites"]
+    assert processed["global_cheapest"]["12"]["price"] == 199.9
+    assert processed["local_cheapest"]["5"]["price"] == 150.0
+
+    coordinator._resolve_entry_coords = lambda: (None, None, None)
+    filtered = coordinator._filter_to_zone([], {}, {})
+    assert filtered["sites"] == {}
+    assert filtered["local_cheapest"] == {}
+
+
+def test_coords_from_state_missing_and_invalid_values():
+    module = _load_coordinator_module()
+    assert module.QldFuelDataUpdateCoordinator._coords_from_state(None) == (None, None)
+    assert module.QldFuelDataUpdateCoordinator._coords_from_state(SimpleNamespace(attributes={})) == (
+        None,
+        None,
+    )
+    assert module.QldFuelDataUpdateCoordinator._coords_from_state(
+        SimpleNamespace(attributes={"latitude": "x", "longitude": 1})
+    ) == (None, None)
+
+
+def test_listener_without_location_and_shutdown_and_empty_cache_recompute():
+    module = _load_coordinator_module()
+    hass = _FakeHass({})
+    entry = SimpleNamespace(data={"scan_interval": 6}, options={}, title="Fuel")
+    coordinator = module.QldFuelDataUpdateCoordinator(hass, entry)
+    asyncio.run(coordinator.async_setup_location_listener())
+    assert coordinator._remove_location_listener is None
+    asyncio.run(coordinator.async_recompute_from_cache())
+    assert coordinator.data == {}
+    asyncio.run(coordinator.async_shutdown())
+    assert coordinator._remove_location_listener is None
+
+
+def test_async_shutdown_invokes_registered_listener_cleanup():
+    module = _load_coordinator_module()
+    hass = _FakeHass({})
+    entry = SimpleNamespace(data={"scan_interval": 6}, options={}, title="Fuel")
+    coordinator = module.QldFuelDataUpdateCoordinator(hass, entry)
+    called = []
+
+    def _remove():
+        called.append(True)
+
+    coordinator._remove_location_listener = _remove
+    asyncio.run(coordinator.async_shutdown())
+    assert called == [True]
+    assert coordinator._remove_location_listener is None
+
+
+def test_async_update_data_wraps_unexpected_exception():
+    module = _load_coordinator_module()
+    module.dt_util.utcnow = lambda: datetime(2026, 1, 1, 0, 0, 0)
+    hass = _FakeHass({"zone.home": _state("Home", -27.5, 153.0)})
+    entry = SimpleNamespace(
+        entry_id="entry-1",
+        data={"scan_interval": 6, "subscriber_token": "token", "zone": "zone.home"},
+        options={},
+        title="Fuel",
+    )
+    coordinator = module.QldFuelDataUpdateCoordinator(hass, entry)
+
+    async def _explode():
+        raise RuntimeError("explode")
+
+    coordinator._fetch_from_api = _explode
+    with pytest.raises(sys.modules["homeassistant.helpers.update_coordinator"].UpdateFailed):
+        asyncio.run(coordinator._async_update_data())
+
+
+def test_filter_to_zone_skips_sites_outside_radius():
+    module = _load_coordinator_module()
+    hass = _FakeHass({})
+    entry = SimpleNamespace(data={"scan_interval": 6, "radius": 0.1}, options={}, title="Fuel")
+    coordinator = module.QldFuelDataUpdateCoordinator(hass, entry)
+    coordinator._resolve_entry_coords = lambda: (-27.5, 153.0, "zone.home")
+    result = coordinator._filter_to_zone(
+        [{"S": "9", "Lat": -25.0, "Lng": 150.0, "N": "Far", "A": "Far", "P": "0000"}],
+        {"9": [{"FuelId": "12", "Price": 150.0}]},
+        {},
+    )
+    assert result["sites"] == {}

--- a/tests/components/qld_fuel/test_diagnostics.py
+++ b/tests/components/qld_fuel/test_diagnostics.py
@@ -1,0 +1,114 @@
+"""Diagnostics tests for qld_fuel."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.no_fail_on_log_exception
+
+
+def _load_diagnostics_module():
+    for key in list(sys.modules):
+        if key == "homeassistant" or key.startswith("homeassistant."):
+            sys.modules.pop(key)
+
+    homeassistant = ModuleType("homeassistant")
+    homeassistant.__path__ = []
+    sys.modules["homeassistant"] = homeassistant
+
+    diagnostics_comp = ModuleType("homeassistant.components.diagnostics")
+
+    def async_redact_data(value, to_redact):
+        if isinstance(value, dict):
+            redacted = {}
+            for key, v in value.items():
+                if key in to_redact:
+                    redacted[key] = "REDACTED"
+                else:
+                    redacted[key] = async_redact_data(v, to_redact)
+            return redacted
+        if isinstance(value, list):
+            return [async_redact_data(v, to_redact) for v in value]
+        return value
+
+    diagnostics_comp.async_redact_data = async_redact_data
+    sys.modules["homeassistant.components.diagnostics"] = diagnostics_comp
+
+    config_entries = ModuleType("homeassistant.config_entries")
+    config_entries.ConfigEntry = object
+    sys.modules["homeassistant.config_entries"] = config_entries
+
+    core = ModuleType("homeassistant.core")
+    core.HomeAssistant = object
+    sys.modules["homeassistant.core"] = core
+
+    const_module = ModuleType("custom_components.qld_fuel.const")
+    const_module.DOMAIN = "qld_fuel"
+    const_module.TOKEN = "subscriber_token"
+    sys.modules["custom_components.qld_fuel.const"] = const_module
+
+    coordinator_module = ModuleType("custom_components.qld_fuel.coordinator")
+
+    class QldFuelDataUpdateCoordinator:
+        def __init__(self, data):
+            self.data = data
+
+    coordinator_module.QldFuelDataUpdateCoordinator = QldFuelDataUpdateCoordinator
+    sys.modules["custom_components.qld_fuel.coordinator"] = coordinator_module
+
+    package = ModuleType("custom_components.qld_fuel")
+    package.__path__ = []
+    sys.modules["custom_components.qld_fuel"] = package
+
+    path = Path("C:/Cursor IDE/qld_fuel-hass/custom_components/qld_fuel/diagnostics.py")
+    spec = importlib.util.spec_from_file_location(
+        "custom_components.qld_fuel.diagnostics",
+        str(path),
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["custom_components.qld_fuel.diagnostics"] = module
+    spec.loader.exec_module(module)
+    return module, QldFuelDataUpdateCoordinator
+
+
+def test_diagnostics_redacts_token_and_returns_snapshots():
+    module, coordinator_cls = _load_diagnostics_module()
+
+    entry = SimpleNamespace(
+        entry_id="entry-1",
+        title="Fuel near Home",
+        data={"subscriber_token": "secret", "zone": "zone.home"},
+        options={},
+        runtime_data=coordinator_cls(
+            {
+                "sites": {"1": {}, "2": {}},
+                "global_cheapest": {"12": {"price": 199.9}},
+                "local_cheapest": {"12": {"price": 189.9}},
+            }
+        ),
+    )
+    hass = SimpleNamespace(
+        data={
+            "qld_fuel": {
+                "last_fetch_time": "2026-04-01T00:00:00",
+                "raw_data": {
+                    "sites": [{"S": "1", "N": "Station 1", "P": "4000", "Lat": -27.5, "Lng": 153.0}],
+                    "prices": [{"FuelId": "12", "SiteId": "1", "Price": 1999}],
+                },
+            }
+        }
+    )
+
+    result = asyncio.run(module.async_get_config_entry_diagnostics(hass, entry))
+
+    assert result["entry"]["data"]["subscriber_token"] == "REDACTED"
+    assert result["cache"]["raw_payload_snapshot"]["sites"]["count"] == 1
+    assert result["cache"]["raw_payload_snapshot"]["prices"]["count"] == 1
+    assert result["coordinator"]["payload_snapshot"]["sites_count"] == 2

--- a/tests/components/qld_fuel/test_integration_lifecycle.py
+++ b/tests/components/qld_fuel/test_integration_lifecycle.py
@@ -1,0 +1,294 @@
+"""Lifecycle tests for qld_fuel __init__ module."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+import pytest
+
+pytestmark = pytest.mark.no_fail_on_log_exception
+
+
+def _load_init_module():
+    for key in list(sys.modules):
+        if key == "homeassistant" or key.startswith("homeassistant."):
+            sys.modules.pop(key)
+
+    homeassistant = ModuleType("homeassistant")
+    homeassistant.__path__ = []
+    sys.modules["homeassistant"] = homeassistant
+
+    const_module = ModuleType("custom_components.qld_fuel.const")
+    const_module.DOMAIN = "qld_fuel"
+    const_module.PLATFORMS = ["sensor"]
+    sys.modules["custom_components.qld_fuel.const"] = const_module
+
+    coordinator_module = ModuleType("custom_components.qld_fuel.coordinator")
+
+    class QldFuelDataUpdateCoordinator:
+        def __init__(self, hass, entry):
+            self.hass = hass
+            self.entry = entry
+            self.data = {}
+            self.shutdown_called = False
+            self.refresh_calls = 0
+
+        async def async_config_entry_first_refresh(self):
+            return None
+
+        async def async_setup_location_listener(self):
+            return None
+
+        async def async_request_refresh(self):
+            self.refresh_calls += 1
+
+        async def async_shutdown(self):
+            self.shutdown_called = True
+
+    coordinator_module.QldFuelDataUpdateCoordinator = QldFuelDataUpdateCoordinator
+    sys.modules["custom_components.qld_fuel.coordinator"] = coordinator_module
+
+    homeassistant_core = ModuleType("homeassistant.core")
+    homeassistant_core.HomeAssistant = object
+    homeassistant_core.ServiceCall = object
+    sys.modules["homeassistant.core"] = homeassistant_core
+
+    homeassistant_exceptions = ModuleType("homeassistant.exceptions")
+
+    class HomeAssistantError(Exception):
+        """HomeAssistantError stub."""
+
+    homeassistant_exceptions.HomeAssistantError = HomeAssistantError
+    sys.modules["homeassistant.exceptions"] = homeassistant_exceptions
+
+    homeassistant_config_entries = ModuleType("homeassistant.config_entries")
+    homeassistant_config_entries.ConfigEntry = object
+    sys.modules["homeassistant.config_entries"] = homeassistant_config_entries
+
+    package = ModuleType("custom_components.qld_fuel")
+    package.__path__ = []
+    sys.modules["custom_components.qld_fuel"] = package
+
+    path = Path("C:/Cursor IDE/qld_fuel-hass/custom_components/qld_fuel/__init__.py")
+    spec = importlib.util.spec_from_file_location("custom_components.qld_fuel", str(path))
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["custom_components.qld_fuel"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Services:
+    def __init__(self):
+        self._handlers = {}
+
+    def has_service(self, domain, service):
+        return (domain, service) in self._handlers
+
+    def async_register(self, domain, service, handler):
+        self._handlers[(domain, service)] = handler
+
+    def async_remove(self, domain, service):
+        self._handlers.pop((domain, service), None)
+
+
+class _ConfigEntries:
+    def __init__(self, entries):
+        self._entries = entries
+        self._unload_ok = True
+        self.updated_entries = []
+        self.reload_calls = []
+
+    async def async_forward_entry_setups(self, _entry, _platforms):
+        return None
+
+    async def async_unload_platforms(self, _entry, _platforms):
+        return self._unload_ok
+
+    def async_entries(self, _domain):
+        return self._entries
+
+    def async_update_entry(self, entry, data=None):
+        self.updated_entries.append((entry, data))
+        entry.data = data or entry.data
+
+    async def async_reload(self, _entry_id):
+        self.reload_calls.append(_entry_id)
+        return None
+
+
+def _make_entry(entry_id: str, is_master: bool):
+    entry = SimpleNamespace(
+        entry_id=entry_id,
+        title=f"Fuel near {entry_id}",
+        data={"is_master": is_master},
+        runtime_data=None,
+    )
+    entry.add_update_listener = lambda _listener: (lambda: None)
+    entry.async_on_unload = lambda _cb: None
+    return entry
+
+
+def test_setup_entry_sets_runtime_data_and_registers_service():
+    module = _load_init_module()
+    entry = _make_entry("entry-1", True)
+    hass = SimpleNamespace(
+        data={},
+        services=_Services(),
+        config_entries=_ConfigEntries([entry]),
+    )
+
+    result = asyncio.run(module.async_setup_entry(hass, entry))
+
+    assert result is True
+    assert entry.runtime_data is not None
+    assert hass.data["qld_fuel"]["master_entry_id"] == "entry-1"
+    assert hass.services.has_service("qld_fuel", "refresh_prices")
+
+
+def test_unload_entry_clears_runtime_data_and_domain_when_last_entry():
+    module = _load_init_module()
+    entry = _make_entry("entry-1", True)
+    hass = SimpleNamespace(
+        data={"qld_fuel": {"master_entry_id": "entry-1"}},
+        services=_Services(),
+        config_entries=_ConfigEntries([entry]),
+    )
+
+    asyncio.run(module.async_setup_entry(hass, entry))
+    assert entry.runtime_data is not None
+
+    result = asyncio.run(module.async_unload_entry(hass, entry))
+
+    assert result is True
+    assert entry.runtime_data is None
+    assert "qld_fuel" not in hass.data
+
+
+def test_refresh_service_runs_for_all_loaded_entries():
+    module = _load_init_module()
+    entry_one = _make_entry("entry-1", True)
+    entry_two = _make_entry("entry-2", False)
+    hass = SimpleNamespace(
+        data={},
+        services=_Services(),
+        config_entries=_ConfigEntries([entry_one, entry_two]),
+    )
+
+    asyncio.run(module.async_setup_entry(hass, entry_one))
+    asyncio.run(module.async_setup_entry(hass, entry_two))
+
+    handler = hass.services._handlers[("qld_fuel", "refresh_prices")]
+    asyncio.run(handler(SimpleNamespace()))
+
+    assert entry_one.runtime_data.refresh_calls == 1
+    assert entry_two.runtime_data.refresh_calls == 1
+
+
+def test_refresh_service_reports_failures_but_continues_refreshing_others():
+    module = _load_init_module()
+    entry_one = _make_entry("entry-1", True)
+    entry_two = _make_entry("entry-2", False)
+    hass = SimpleNamespace(
+        data={},
+        services=_Services(),
+        config_entries=_ConfigEntries([entry_one, entry_two]),
+    )
+
+    asyncio.run(module.async_setup_entry(hass, entry_one))
+    asyncio.run(module.async_setup_entry(hass, entry_two))
+    entry_one.runtime_data.async_request_refresh = _failing_refresh
+
+    handler = hass.services._handlers[("qld_fuel", "refresh_prices")]
+
+    asyncio.run(handler(SimpleNamespace()))
+
+    assert entry_two.runtime_data.refresh_calls == 1
+
+
+async def _failing_refresh():
+    raise RuntimeError("boom")
+
+
+def test_iter_runtime_coordinators_skips_non_coordinators():
+    module = _load_init_module()
+    valid_entry = _make_entry("entry-1", True)
+    invalid_entry = _make_entry("entry-2", False)
+    invalid_entry.runtime_data = object()
+    hass = SimpleNamespace(
+        data={},
+        services=_Services(),
+        config_entries=_ConfigEntries([valid_entry, invalid_entry]),
+    )
+    asyncio.run(module.async_setup_entry(hass, valid_entry))
+    found = list(module._iter_runtime_coordinators(hass))
+    assert len(found) == 1
+
+
+def test_setup_entry_does_not_reregister_existing_service():
+    module = _load_init_module()
+    entry = _make_entry("entry-1", True)
+    services = _Services()
+    services._handlers[("qld_fuel", "refresh_prices")] = lambda _call: None
+    hass = SimpleNamespace(data={}, services=services, config_entries=_ConfigEntries([entry]))
+    asyncio.run(module.async_setup_entry(hass, entry))
+    assert len(services._handlers) == 1
+
+
+def test_refresh_service_unknown_entry_id_on_missing_entry_attr():
+    module = _load_init_module()
+    entry = _make_entry("entry-1", True)
+    hass = SimpleNamespace(
+        data={},
+        services=_Services(),
+        config_entries=_ConfigEntries([entry]),
+    )
+    asyncio.run(module.async_setup_entry(hass, entry))
+    entry.runtime_data.entry = SimpleNamespace()
+    entry.runtime_data.async_request_refresh = _failing_refresh
+    handler = hass.services._handlers[("qld_fuel", "refresh_prices")]
+    asyncio.run(handler(SimpleNamespace()))
+
+
+def test_unload_entry_false_does_not_clear_runtime():
+    module = _load_init_module()
+    entry = _make_entry("entry-1", True)
+    config_entries = _ConfigEntries([entry])
+    config_entries._unload_ok = False
+    hass = SimpleNamespace(
+        data={"qld_fuel": {"master_entry_id": "entry-1"}},
+        services=_Services(),
+        config_entries=config_entries,
+    )
+    asyncio.run(module.async_setup_entry(hass, entry))
+    assert asyncio.run(module.async_unload_entry(hass, entry)) is False
+    assert entry.runtime_data is not None
+
+
+def test_unload_master_promotes_next_entry():
+    module = _load_init_module()
+    master = _make_entry("entry-1", True)
+    other = _make_entry("entry-2", False)
+    hass = SimpleNamespace(
+        data={"qld_fuel": {"master_entry_id": "entry-1"}},
+        services=_Services(),
+        config_entries=_ConfigEntries([master, other]),
+    )
+    asyncio.run(module.async_setup_entry(hass, master))
+    asyncio.run(module.async_setup_entry(hass, other))
+    assert asyncio.run(module.async_unload_entry(hass, master)) is True
+    assert hass.data["qld_fuel"]["master_entry_id"] == "entry-2"
+    assert hass.config_entries.updated_entries
+
+
+def test_reload_and_remove_device_helpers():
+    module = _load_init_module()
+    entry = _make_entry("entry-1", True)
+    config_entries = _ConfigEntries([entry])
+    hass = SimpleNamespace(data={}, services=_Services(), config_entries=config_entries)
+    asyncio.run(module.async_reload_entry(hass, entry))
+    assert config_entries.reload_calls == ["entry-1"]
+    assert asyncio.run(module.async_remove_config_entry_device(hass, entry, object())) is True

--- a/tests/components/qld_fuel/test_sensor_runtime_and_naming.py
+++ b/tests/components/qld_fuel/test_sensor_runtime_and_naming.py
@@ -1,0 +1,430 @@
+"""Sensor module tests for naming and runtime_data behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.no_fail_on_log_exception
+
+
+def _load_sensor_module():
+    for key in list(sys.modules):
+        if key == "homeassistant" or key.startswith("homeassistant."):
+            sys.modules.pop(key)
+
+    homeassistant = ModuleType("homeassistant")
+    homeassistant.__path__ = []
+    sys.modules["homeassistant"] = homeassistant
+
+    const_module = ModuleType("custom_components.qld_fuel.const")
+    const_module.DOMAIN = "qld_fuel"
+    const_module.FUEL_TYPES = "fuel_types"
+    const_module.FUEL_TYPES_OPTIONS = [{"value": "12", "label": "E10"}]
+    const_module.LOCATION_ENTITY = "location_entity"
+    const_module.RADIUS = "radius"
+    sys.modules["custom_components.qld_fuel.const"] = const_module
+
+    recorder = ModuleType("homeassistant.components.recorder")
+    recorder.history = SimpleNamespace(get_significant_states=lambda *_a, **_k: {})
+    recorder.get_instance = lambda _hass: SimpleNamespace(
+        async_add_executor_job=lambda *_a, **_k: {}
+    )
+    sys.modules["homeassistant.components.recorder"] = recorder
+
+    sensor_comp = ModuleType("homeassistant.components.sensor")
+
+    class SensorEntity:
+        def async_write_ha_state(self):
+            return None
+
+    sensor_comp.SensorEntity = SensorEntity
+    sensor_comp.SensorStateClass = SimpleNamespace(MEASUREMENT="measurement")
+    sensor_comp.SensorDeviceClass = SimpleNamespace(TIMESTAMP="timestamp")
+    sys.modules["homeassistant.components.sensor"] = sensor_comp
+
+    core = ModuleType("homeassistant.core")
+    core.callback = lambda func: func
+    sys.modules["homeassistant.core"] = core
+
+    helpers = ModuleType("homeassistant.helpers")
+    helpers.__path__ = []
+    sys.modules["homeassistant.helpers"] = helpers
+
+    entity_module = ModuleType("homeassistant.helpers.entity")
+    entity_module.EntityCategory = SimpleNamespace(DIAGNOSTIC="diagnostic")
+    sys.modules["homeassistant.helpers.entity"] = entity_module
+
+    entity_registry = ModuleType("homeassistant.helpers.entity_registry")
+    entity_registry.async_get = lambda _hass: SimpleNamespace(
+        async_get_entity_id=lambda *_a, **_k: None
+    )
+    entity_registry.async_entries_for_config_entry = lambda *_a, **_k: []
+    sys.modules["homeassistant.helpers.entity_registry"] = entity_registry
+
+    device_registry = ModuleType("homeassistant.helpers.device_registry")
+    device_registry.DeviceEntryType = SimpleNamespace(SERVICE="service")
+    device_registry.DeviceInfo = dict
+    sys.modules["homeassistant.helpers.device_registry"] = device_registry
+
+    update_coordinator = ModuleType("homeassistant.helpers.update_coordinator")
+
+    class CoordinatorEntity:
+        def __init__(self, coordinator):
+            self.coordinator = coordinator
+            self.hass = coordinator.hass
+
+        async def async_added_to_hass(self):
+            return None
+
+        def _handle_coordinator_update(self):
+            return None
+
+    update_coordinator.CoordinatorEntity = CoordinatorEntity
+    sys.modules["homeassistant.helpers.update_coordinator"] = update_coordinator
+
+    dt_util = ModuleType("homeassistant.util.dt")
+    dt_util.utcnow = lambda: None
+    sys.modules["homeassistant.util.dt"] = dt_util
+
+    util = ModuleType("homeassistant.util")
+    util.__path__ = []
+    util.dt = dt_util
+    sys.modules["homeassistant.util"] = util
+
+    util_location = ModuleType("homeassistant.util.location")
+    util_location.distance = lambda *_a, **_k: 0
+    sys.modules["homeassistant.util.location"] = util_location
+
+    package = ModuleType("custom_components.qld_fuel")
+    package.__path__ = []
+    sys.modules["custom_components.qld_fuel"] = package
+
+    path = Path("C:/Cursor IDE/qld_fuel-hass/custom_components/qld_fuel/sensor.py")
+    spec = importlib.util.spec_from_file_location(
+        "custom_components.qld_fuel.sensor",
+        str(path),
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["custom_components.qld_fuel.sensor"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sensor_module_exposes_parallel_updates_and_entity_name():
+    module = _load_sensor_module()
+    assert module.PARALLEL_UPDATES == 1
+    assert module.QldFuelBestPriceSensor._attr_has_entity_name is True
+    assert module.FuelPriceSensor._attr_has_entity_name is True
+    assert module.QldFuelBestPriceSensor._attr_device_class is None
+    assert module.FuelPriceSensor._attr_device_class is None
+
+
+def test_best_price_sensor_marks_aggregate_scopes_as_diagnostic():
+    module = _load_sensor_module()
+
+    hass = SimpleNamespace(states=SimpleNamespace(get=lambda _entity_id: None))
+    entry = SimpleNamespace(
+        entry_id="entry_1",
+        data={},
+        options={},
+        title="Home",
+    )
+    coordinator = SimpleNamespace(hass=hass, entry=entry)
+
+    nearby = module.QldFuelBestPriceSensor(coordinator, "12", "nearby")
+    local = module.QldFuelBestPriceSensor(coordinator, "12", "local")
+    global_sensor = module.QldFuelBestPriceSensor(coordinator, "12", "global")
+
+    assert nearby._attr_entity_category is None
+    assert local._attr_entity_category is None
+    assert global_sensor._attr_entity_category == "diagnostic"
+
+
+def test_find_all_tracked_best_uses_entry_runtime_data():
+    module = _load_sensor_module()
+
+    entry_1 = SimpleNamespace(
+        runtime_data=SimpleNamespace(data={"local_cheapest": {"12": {"price": 199.9}}})
+    )
+    entry_2 = SimpleNamespace(
+        runtime_data=SimpleNamespace(data={"local_cheapest": {"12": {"price": 189.5}}})
+    )
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(async_entries=lambda _domain: [entry_1, entry_2])
+    )
+
+    best_price, station = module._find_all_tracked_best(hass, "12")
+    assert best_price == 189.5
+    assert station["price"] == 189.5
+
+
+def _build_coordinator(module):
+    state_lookup = {
+        "zone.home": SimpleNamespace(name="Home"),
+        "person.me": SimpleNamespace(name="Tracker"),
+    }
+    hass = SimpleNamespace(
+        states=SimpleNamespace(get=lambda entity_id: state_lookup.get(entity_id)),
+        config_entries=SimpleNamespace(async_entries=lambda _domain: []),
+        data={"qld_fuel": {"raw_data": {"sites": []}}},
+        is_stopping=False,
+        async_create_task=lambda coro: None,
+    )
+    entry = SimpleNamespace(
+        entry_id="entry_1",
+        data={"zone": "zone.home", "radius": 5, "location_entity": "person.me"},
+        options={},
+        title="Fuel near Home",
+    )
+    return SimpleNamespace(hass=hass, entry=entry, data={})
+
+
+def test_get_fuel_data_and_location_source():
+    module = _load_sensor_module()
+    assert module.get_fuel_data(None, "12") is None
+    assert module.get_fuel_data({"12": {"price": 1}}, "12") == {"price": 1}
+    entry = SimpleNamespace(data={"location_entity": "person.me"}, options={})
+    assert module._resolve_location_source(entry) == "person.me"
+    entry = SimpleNamespace(data={}, options={"location_entity": 42})
+    assert module._resolve_location_source(entry) is None
+
+
+def test_remove_stale_entities_removes_only_matching_prefix():
+    module = _load_sensor_module()
+    removed = []
+    registry = SimpleNamespace(async_remove=lambda entity_id: removed.append(entity_id))
+    module.er.async_get = lambda _hass: registry
+    module.er.async_entries_for_config_entry = lambda _registry, _entry_id: [
+        SimpleNamespace(unique_id="qld_fuel_entry_1_12_1", entity_id="sensor.keep"),
+        SimpleNamespace(unique_id="qld_fuel_entry_1_12_2", entity_id="sensor.remove"),
+        SimpleNamespace(unique_id="other_prefix", entity_id="sensor.other"),
+    ]
+    module._remove_stale_entities(
+        SimpleNamespace(),
+        SimpleNamespace(entry_id="entry_1"),
+        {"qld_fuel_entry_1_12_1"},
+    )
+    assert removed == ["sensor.remove"]
+
+
+def test_remove_stale_entities_skips_entries_without_unique_id():
+    module = _load_sensor_module()
+    removed = []
+    registry = SimpleNamespace(async_remove=lambda entity_id: removed.append(entity_id))
+    module.er.async_get = lambda _hass: registry
+    module.er.async_entries_for_config_entry = lambda *_a, **_k: [
+        SimpleNamespace(unique_id=None, entity_id="sensor.none"),
+    ]
+    module._remove_stale_entities(SimpleNamespace(), SimpleNamespace(entry_id="entry_1"), set())
+    assert removed == []
+
+
+def test_last_api_response_sensor_reads_shared_fetch_time():
+    module = _load_sensor_module()
+    coordinator = _build_coordinator(module)
+    ts = datetime(2026, 4, 1, 0, 0, 0, tzinfo=timezone.utc)
+    coordinator.hass.data["qld_fuel"]["last_fetch_time"] = ts
+    coordinator.last_update_success = True
+    sensor = module.QldFuelLastApiResponseSensor(coordinator)
+    assert sensor.native_value == ts
+    assert sensor.extra_state_attributes["last_update_success"] is True
+    assert sensor._attr_unique_id == "qld_fuel_entry_1_last_api_response"
+
+
+def test_async_setup_entry_creates_entities_for_master_and_local():
+    module = _load_sensor_module()
+    coordinator = _build_coordinator(module)
+    coordinator.data = {
+        "sites": {
+            "1": {"name": "Station 1", "prices": [{"FuelId": "12", "Price": 199.9}]},
+            "2": {"prices": []},
+        }
+    }
+    coordinator.entry.data["fuel_types"] = ["12"]
+    hass = coordinator.hass
+    hass.data["qld_fuel"]["master_entry_id"] = "entry_1"
+    coordinator.entry.runtime_data = coordinator
+    added = []
+    asyncio.run(module.async_setup_entry(hass, coordinator.entry, lambda entities: added.extend(entities)))
+    assert added
+    names = {entity._attr_unique_id for entity in added}
+    assert "qld_fuel_global_12" in names
+    assert "qld_fuel_tracked_12" in names
+    assert "qld_fuel_entry_1_last_api_response" in names
+
+
+def test_best_price_sensor_native_values_and_attributes():
+    module = _load_sensor_module()
+    coordinator = _build_coordinator(module)
+    coordinator.data = {
+        "global_cheapest": {"12": {"price": 199.9, "site_id": "1"}},
+        "local_cheapest": {"12": {"price": 189.9, "site_id": "1"}},
+    }
+    coordinator.hass.data["qld_fuel"]["raw_data"]["sites"] = [
+        {"S": "1", "N": "Station 1", "A": "Main", "P": "4000", "Lat": -27.5, "Lng": 153.0}
+    ]
+    coordinator._resolve_entry_coords = lambda: (-27.5, 153.0, "zone.home")
+    global_sensor = module.QldFuelBestPriceSensor(coordinator, "12", "global")
+    assert global_sensor.native_value == 199.9
+    attrs = global_sensor.extra_state_attributes
+    assert attrs["station_name"] == "Station 1"
+
+    local_sensor = module.QldFuelBestPriceSensor(coordinator, "12", "local")
+    assert local_sensor.native_value == 189.9
+    nearby_sensor = module.QldFuelBestPriceSensor(coordinator, "12", "nearby")
+    nearby_attrs = nearby_sensor.extra_state_attributes
+    assert nearby_attrs["reason"] == "ok"
+
+    global_device = global_sensor.device_info
+    assert global_device["name"] == "Queensland Fuel Prices"
+    local_device = local_sensor.device_info
+    assert local_device["name"] == "Fuel near Home"
+
+
+def test_best_price_sensor_all_tracked_native_value_and_attributes():
+    module = _load_sensor_module()
+    coordinator = _build_coordinator(module)
+    entry_1 = SimpleNamespace(runtime_data=SimpleNamespace(data={"local_cheapest": {"12": {"price": 170.0, "site_id": "1"}}}))
+    entry_2 = SimpleNamespace(runtime_data=SimpleNamespace(data={"local_cheapest": {"12": {"price": 160.0, "site_id": "2"}}}))
+    coordinator.hass.config_entries = SimpleNamespace(async_entries=lambda _domain: [entry_1, entry_2])
+    sensor = module.QldFuelBestPriceSensor(coordinator, "12", "all_tracked")
+    assert sensor.native_value == 160.0
+    attrs = sensor.extra_state_attributes
+    assert attrs["status"].startswith("Site")
+
+
+def test_best_price_sensor_handles_missing_station_data_paths():
+    module = _load_sensor_module()
+    coordinator = _build_coordinator(module)
+    coordinator.data = {"local_cheapest": {}, "global_cheapest": {}}
+    sensor = module.QldFuelBestPriceSensor(coordinator, "12", "nearby")
+    attrs = sensor.extra_state_attributes
+    assert attrs["reason"] == "no_stations_in_range"
+
+    coordinator.data = {"local_cheapest": {"12": {"price": 1.0}}, "global_cheapest": {}}
+    sensor2 = module.QldFuelBestPriceSensor(coordinator, "12", "local")
+    assert sensor2.extra_state_attributes["status"] == "Price found but site_id is missing"
+
+    sensor3 = module.QldFuelBestPriceSensor(coordinator, "12", "global")
+    assert sensor3.extra_state_attributes["status"].startswith("No data")
+
+    assert sensor2._find_station_entity_id({}) is None
+
+
+def test_fuel_price_sensor_values_attributes_and_history():
+    module = _load_sensor_module()
+    now = datetime(2026, 4, 1, 0, 0, 0)
+    module.dt_util.utcnow = lambda: now
+    coordinator = _build_coordinator(module)
+    coordinator.data = {
+        "sites": {
+            "1": {
+                "name": "Station 1",
+                "address": "Main",
+                "postcode": "4000",
+                "latitude": -27.5,
+                "longitude": 153.0,
+                "distance": 1.2,
+                "prices": [{"FuelId": "12", "Price": 199.9}],
+                "stats": {"12": {"qld_delta": 2.1}},
+            }
+        }
+    }
+    sensor = module.FuelPriceSensor(coordinator, "1", "12")
+    sensor.entity_id = "sensor.station_1"
+    assert sensor.native_value == 199.9
+    assert sensor.device_info["name"] == "Fuel near Home"
+    attrs = sensor.extra_state_attributes
+    assert attrs["difference_to_qld_cheapest"] == 2.1
+    assert "Location" in attrs
+
+    points = [
+        SimpleNamespace(state="199.9", last_changed=now - timedelta(days=1)),
+        SimpleNamespace(state="189.9", last_changed=now - timedelta(days=3)),
+        SimpleNamespace(state="bad", last_changed=now - timedelta(days=2)),
+    ]
+    async def _executor(*_a, **_k):
+        return {"sensor.station_1": points}
+
+    module.get_instance = lambda _hass: SimpleNamespace(async_add_executor_job=_executor)
+    asyncio.run(sensor._update_history())
+    assert sensor._14d_low == 189.9
+    assert sensor._7d_low == 189.9
+
+    attrs2 = sensor.extra_state_attributes
+    assert "7_day_low" in attrs2
+    assert "14_day_low" in attrs2
+
+
+def test_fuel_price_sensor_native_value_missing_fuel_returns_none():
+    module = _load_sensor_module()
+    coordinator = _build_coordinator(module)
+    coordinator.data = {"sites": {"1": {"name": "Station 1", "prices": [{"FuelId": "5", "Price": 150.0}]}}}
+    sensor = module.FuelPriceSensor(coordinator, "1", "12")
+    assert sensor.native_value is None
+
+
+def test_fuel_price_sensor_history_error_and_stop_paths():
+    module = _load_sensor_module()
+    module.dt_util.utcnow = lambda: datetime(2026, 4, 1, 0, 0, 0)
+    coordinator = _build_coordinator(module)
+    sensor = module.FuelPriceSensor(coordinator, "1", "12")
+    sensor.entity_id = "sensor.station_1"
+    coordinator.hass.is_stopping = True
+    asyncio.run(sensor._update_history())
+    coordinator.hass.is_stopping = False
+
+    class _ErrInstance:
+        async def async_add_executor_job(self, *_a, **_k):
+            raise ValueError("no history")
+
+    module.get_instance = lambda _hass: _ErrInstance()
+    asyncio.run(sensor._update_history())
+
+
+def test_fuel_price_sensor_added_and_coordinator_update_hooks():
+    module = _load_sensor_module()
+    module.dt_util.utcnow = lambda: datetime(2026, 4, 1, 0, 0, 0)
+    coordinator = _build_coordinator(module)
+    scheduled = []
+    coordinator.hass.async_create_task = lambda coro: scheduled.append(coro)
+    sensor = module.FuelPriceSensor(coordinator, "1", "12")
+    sensor.entity_id = "sensor.station_1"
+
+    async def _fake_history():
+        return None
+
+    sensor._update_history = _fake_history
+    asyncio.run(sensor.async_added_to_hass())
+    sensor._handle_coordinator_update()
+    assert len(scheduled) == 1
+    scheduled[0].close()
+
+
+def test_history_ignores_unavailable_points():
+    module = _load_sensor_module()
+    now = datetime(2026, 4, 1, 0, 0, 0)
+    module.dt_util.utcnow = lambda: now
+    coordinator = _build_coordinator(module)
+    sensor = module.FuelPriceSensor(coordinator, "1", "12")
+    sensor.entity_id = "sensor.station_1"
+
+    points = [
+        SimpleNamespace(state="unavailable", last_changed=now - timedelta(days=1)),
+        SimpleNamespace(state="190.0", last_changed=now - timedelta(days=2)),
+    ]
+
+    async def _executor(*_a, **_k):
+        return {"sensor.station_1": points}
+
+    module.get_instance = lambda _hass: SimpleNamespace(async_add_executor_job=_executor)
+    asyncio.run(sensor._update_history())
+    assert sensor._14d_low == 190.0


### PR DESCRIPTION
## Summary
Adds an optional tracked location source (person, device_tracker, or sensors with latitude/longitude) with zone fallback
Plus diagnostics, repairs issues, tests, CI, and docs. Manual `refresh_prices` logs warnings for partial failures instead of raising and traceback spam. Aligns with Home Assistant integration requirement checklist.

Addresses the device-tracker / location request discussed in https://github.com/spusuf/qld_fuel-hass/issues/3

## Base branch
Stacked on `feature/location-attributes-issue-3` (PR 5). Merge or rebase after PR 5 lands upstream as needed.

## Tests
`scripts/run-tests.ps1` (63 passed, coverage gate met)

Refs https://github.com/spusuf/qld_fuel-hass/issues/3